### PR TITLE
Fix crash due to missing list element in breathe/renderer/rst/doxygen/compound.py

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -123,6 +123,7 @@ class SectionDefTypeSubRenderer(Renderer):
                 "private-type": "Private Types",
                 "private-func": "Private Functions",
                 "private-attrib": "Private Members",
+                "package-func": "Package Functions",
                 "private-slot":  "Private Slots",
                 "private-static-func": "Private Static Functions",
                 "private-static-attrib":  "Private Static Attributes",


### PR DESCRIPTION
Add missing field "package-func" to section_titles of SectionDefTypeSubRenderer() in doxygen/compound.py
