### PR TITLE
Migrating from print statement to function

### DIFF
--- a/breathe/parser/doxygen/compoundsuper.py
+++ b/breathe/parser/doxygen/compoundsuper.py
@@ -5743,7 +5743,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/breathe/parser/doxygen/indexsuper.py
+++ b/breathe/parser/doxygen/indexsuper.py
@@ -301,7 +301,7 @@ Options:
 """
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -142,9 +142,9 @@ class DoxygenToRstRendererFactory(object):
             elif data_object.type_ == "subscript":
                 creator = self.node_factory.subscript
             elif data_object.type_ == "center":
-                print "Warning: does not currently handle 'center' text display"
+                print("Warning: does not currently handle 'center' text display")
             elif data_object.type_ == "small":
-                print "Warning: does not currently handle 'small' text display"
+                print("Warning: does not currently handle 'small' text display")
 
             return Renderer(
                     creator,

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -161,8 +161,8 @@ class CppDomainHandler(DomainHandler):
         # Check if we've already got this id
         in_cache, project = self.helper.check_cache(id_)
         if in_cache:
-            print "Warning: Ignoring duplicate domain reference '%s'. " \
-                  "First found in project '%s'" % (id_, project.reference())
+            print("Warning: Ignoring duplicate domain reference '%s'. "
+                  "First found in project '%s'" % (id_, project.reference()))
             return []
 
         self.helper.cache(id_, self.project_info)

--- a/breathe/renderer/rst/doxygen/target.py
+++ b/breathe/renderer/rst/doxygen/target.py
@@ -16,7 +16,7 @@ class TargetHandler(object):
             self.document.note_explicit_target(target)
         except Exception:
             # TODO: We should really return a docutils warning node here
-            print "Duplicate target detected: %s" % id_
+            print("Duplicate target detected: %s" % id_)
 
         return [target]
 


### PR DESCRIPTION
We should move from print statement to print function call in a first time.

In a second time, it could be interesting to use the logging module to have a more standard and flexible approach. 
