### PR TITLE
Add possibility to resolve partial template specializations.

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -245,7 +245,7 @@ class DoxygenFunctionDirective(BaseDirective):
             target_handler = self.target_handler_factory.create_target_handler(
                 {'no-link': u''}, project_info, self.state.document
                 )
-            filter_ = self.filter_factory.create_outline_filter({'outline', ''})
+            filter_ = self.filter_factory.create_outline_filter(set(['outline', '']))
             mask_factory = MaskFactory({'param': NoParameterNamesMask})
             nodes = self.render(entry, project_info, filter_, target_handler, mask_factory)
 


### PR DESCRIPTION
Example: The class

```
template <typename T>
class Specialization<T*> {};
```

can be accessed via

```
.. doxygenclass:: Specialization< T * >
```

The white-spaces are necessary. This changeset addresses issue #113 but is far
from being complete. Still, the argument of sphinx directives must match
exactly the doxygen XML node name including white-spaces. A better solution
is needed for that.
