### PR TITLE
Don't check for duplicate ids in cpp domain.

### DIFF
--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -13,17 +13,6 @@ class CppDomainHelper(DomainHelper):
         self.definition_parser = definition_parser
         self.substitute = substitute
 
-        self.duplicates = {}
-
-    def check_cache(self, _id):
-        try:
-            return True, self.duplicates[_id]
-        except KeyError:
-            return False, ""
-
-    def cache(self, _id, project_info):
-        self.duplicates[_id] = project_info
-
     def remove_word(self, word, definition):
         return self.substitute(r"(\s*\b|^)%s\b\s*" % word, "", definition)
 
@@ -157,15 +146,6 @@ class CppDomainHandler(DomainHandler):
         """Creates a target node and registers it with the appropriate domain
         object list in a style which matches Sphinx's behaviour for the domain
         directives like cpp:function"""
-
-        # Check if we've already got this id
-        in_cache, project = self.helper.check_cache(id_)
-        if in_cache:
-            print("Warning: Ignoring duplicate domain reference '%s'. "
-                  "First found in project '%s'" % (id_, project.reference()))
-            return []
-
-        self.helper.cache(id_, self.project_info)
 
         # Create target node. This is required for LaTeX output as target nodes are converted to the
         # appropriate \phantomsection & \label for in document LaTeX links

--- a/breathe/renderer/rst/doxygen/target.py
+++ b/breathe/renderer/rst/doxygen/target.py
@@ -16,7 +16,7 @@ class TargetHandler(object):
             self.document.note_explicit_target(target)
         except Exception:
             # TODO: We should really return a docutils warning node here
-            print("Duplicate target detected: %s" % id_)
+            print("Warning: Duplicate target detected: %s" % id_)
 
         return [target]
 


### PR DESCRIPTION
The proposed PR removes the check for duplicate ids in the cpp domain. This is done for the following reasons:
1. The check prevents target generation when the same node is rendered more than once. This happens when rendering matches during function overload resolution.
2. Duplicates are aslo diagnosed by TargetHandler (https://github.com/michaeljones/breathe/blob/e0aac07816081118ccbb372890c9d37f3715d22a/breathe/renderer/rst/doxygen/target.py#L19) as "Duplicate target detected: {id}" and Sphinx itself as "Duplicate ID: "{id}"".

Fixes issue https://github.com/michaeljones/breathe/issues/125.
