### PR TITLE
Don't add empty desc nodes

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -73,18 +73,20 @@ class CompoundDefTypeSubRenderer(Renderer):
 
         # Get all sub sections
         for sectiondef in self.data_object.sectiondef:
+            context = self.context.create_child_context(sectiondef)
+            renderer = self.renderer_factory.create_renderer(context)
+            child_nodes = renderer.render()
+            if len(child_nodes) == 0:
+                # Sphinx doesn't allow empty desc nodes
+                continue
             kind = sectiondef.kind
             node = self.node_factory.desc()
             node.document = self.state.document
             node['objtype'] = kind
-            context = self.context.create_child_context(sectiondef)
-            renderer = self.renderer_factory.create_renderer(context)
-            node.extend(renderer.render())
-            try:
-                # As "user-defined" can repeat
-                section_nodelists[kind] += [node]
-            except KeyError:
-                section_nodelists[kind] = [node]
+            node.extend(child_nodes)
+            # As "user-defined" can repeat
+            nodes = section_nodelists.setdefault(kind, [])
+            nodes += [node]
 
         # Order the results in an appropriate manner
         for kind, _ in self.sections:


### PR DESCRIPTION
Empty desc nodes break LaTeX markup and are not permitted according to the [Sphinx documentation](http://sphinx-doc.org/extdev/nodes.html#sphinx.addnodes.desc):

> It (desc node) contains one or more desc_signature and a desc_content.

This partially addresses issue https://github.com/michaeljones/breathe/issues/127.

Also the node insertion code is slightly simplified (`try-except` block is not needed):

``` python
try:
  # As "user-defined" can repeat
  section_nodelists[kind] += [node]
except KeyError:
  section_nodelists[kind] = [node]
```

changed to

``` python
# As "user-defined" can repeat
nodes = section_nodelists.setdefault(kind, [])
nodes += [node]
```
