### PR TITLE
Generate additional desc_signature node for function templates

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -203,6 +203,11 @@ class MemberDefTypeSubRenderer(Renderer):
 
         return nodes
 
+    def build_signodes(self, signode):
+
+        # Build title nodes
+        signode.extend(self.title())
+        return [signode]
 
     def render(self):
 
@@ -211,8 +216,7 @@ class MemberDefTypeSubRenderer(Renderer):
         signode.extend(self.create_domain_target())
         signode.extend(self.create_doxygen_target())
 
-        # Build title nodes
-        signode.extend(self.title())
+        signodes = self.build_signodes(signode)
 
         # Build description nodes
         contentnode = self.node_factory.desc_content()
@@ -221,7 +225,7 @@ class MemberDefTypeSubRenderer(Renderer):
         node = self.node_factory.desc()
         node.document = self.state.document
         node['objtype'] = self.data_object.kind
-        node.append(signode)
+        node.extend(signodes)
         node.append(contentnode)
 
         return [node]
@@ -233,9 +237,9 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
         return self.domain_handler.create_function_target(self.data_object)
 
-    def title(self):
+    def build_signodes(self, signode):
 
-        nodes = []
+        signodes = [signode]
 
         # Handle any template information
         if self.data_object.templateparamlist:
@@ -244,7 +248,17 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
             template_nodes = [self.node_factory.Text("template <")]
             template_nodes.extend(renderer.render())
             template_nodes.append(self.node_factory.Text("> "))
-            nodes.append(self.node_factory.line("", *template_nodes))
+            signode.extend(template_nodes)
+            signode = self.node_factory.desc_signature()
+            signodes.append(signode)
+
+        # Build title nodes
+        signode.extend(self.title())
+        return signodes
+
+    def title(self):
+
+        nodes = []
 
         # Note whether a member function is virtual
         if self.data_object.virt != 'non-virtual':


### PR DESCRIPTION
We need to render templates on two lines but desc_signature doesn't permit multiple lines. So add two desc_signature nodes for function templates, one for template <...> part and another for the rest.

The idea is similar to that of PR https://github.com/michaeljones/breathe/pull/130, but the implementation is somewhat more complicated because the logic for creating signodes is split between `render()` and `title()`. I tried to minimize changes and not sure if this is the best implementation, so you might need to clean this up a bit.

BTW it might be a good idea to factor out the `template <...>` processing logic into one function because currently there is some duplication in handling function and class templates.

Fixes the third part of issue https://github.com/michaeljones/breathe/issues/127 (https://github.com/michaeljones/breathe/issues/127#issuecomment-58512603)
