### PR TITLE
Replacing signature nodes with section nodes for sections

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -77,10 +77,10 @@ class CompoundDefTypeSubRenderer(Renderer):
             renderer = self.renderer_factory.create_renderer(context)
             child_nodes = renderer.render()
             if not child_nodes:
-                # Sphinx doesn't allow empty desc nodes
+                # Skip empty section
                 continue
             kind = sectiondef.kind
-            node = self.node_factory.desc()
+            node = self.node_factory.compound()
             node.document = self.state.document
             node['objtype'] = kind
             node.extend(child_nodes)
@@ -141,12 +141,11 @@ class SectionDefTypeSubRenderer(Renderer):
                 else:
                     text = "Unnamed Group"
 
-            section = self.node_factory.section()
-            section["ids"] = [self.data_object.kind]
-            section += self.node_factory.title(text=text)
-            section.extend(node_list)
+            # Use rubric for the title because, unlike the docutils element "section",
+            # it doesn't interfere with the document structure.
+            rubric = self.node_factory.rubric(text=text)
 
-            return [section]
+            return [rubric] + node_list
 
         return []
 


### PR DESCRIPTION
The proposed PR replaces signature nodes with section nodes for sections such as "Public Functions". Addresses Issue https://github.com/michaeljones/breathe/issues/136. Here's an example demonstrating the new rendering: http://cppformat.readthedocs.org/en/master/reference.html#public-func.

Unfortunately I couldn't find how to get the class name (or other context information) in `SectionDefTypeSubRenderer.render` so the ID [generated here](https://github.com/vitaut/breathe/commit/3582fe74c8e88217e2c7e9f841ca7614dc8a22ab#diff-0aaed0bd876736d6921605602deb9b8eR145) simply uses `data_object.kind` which is not unique. It would be better to have `<class-name>:<kind>` (e.g. `fmt::BasicWriter:public-func`) or something similar depending on section type. Michael, could you suggest how to do this?
