### PR TITLE
handle Sphinx's fix for C domain name conflicts

### DIFF
--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -98,7 +98,7 @@ class CDomainHandler(DomainHandler):
 
         # Create target node. This is required for LaTeX output as target nodes are converted to the
         # appropriate \phantomsection & \label for in document LaTeX links
-        (target,) = self.target_handler.create_target(name)
+        (target,) = self.target_handler.create_target('c.' + name)
 
         inv = self.env.domaindata['c']['objects']
         if name in inv:


### PR DESCRIPTION
Commit [b2a0904](https://bitbucket.org/birkenfeld/sphinx/commits/b2a090415961d5efb00dabe3614e978fb853f0be) added a "c." prefix to all targets in the C domain. As a result, links to breathe-generated targets [don't work](http://breathe.readthedocs.org/en/latest/domains.html) because the anchors and IDs don't match. This change allows links to breathe-generated targets to work again.