### PR TITLE
Improve section naming consistency

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -18,7 +18,7 @@ class CompoundDefTypeSubRenderer(Renderer):
     # having two lists in case they fall out of sync
     sections = [
                 ("user-defined", "User Defined"),
-                ("public-type", "Public Type"),
+                ("public-type", "Public Types"),
                 ("public-func", "Public Functions"),
                 ("public-attrib", "Public Members"),
                 ("public-slot", "Public Slots"),


### PR DESCRIPTION
Little PR that changes "Public Type" to "Public Types" section name for consistency with "Public Functions" etc. and to check that I can create and push to branches.