### PR TITLE
Replace matcher stack with finder filter

### DIFF
--- a/breathe/renderer/rst/doxygen/filter.py
+++ b/breathe/renderer/rst/doxygen/filter.py
@@ -1063,14 +1063,15 @@ class FilterFactory(object):
 
         return filter_
 
-    def create_function_finder_filter(self, namespace, function_name):
+    def create_member_finder_filter(self, namespace, name, kind):
+        """Returns a filter which looks for a member with the specified name and kind."""
 
         node = Node()
         parent = Parent()
 
         node_matches = (node.node_type == 'member') \
-                & (node.kind == 'function') \
-                & (node.name == function_name)
+                & (node.kind == kind) \
+                & (node.name == name)
 
         if namespace:
             parent_matches = (parent.node_type == 'compound') \
@@ -1087,6 +1088,12 @@ class FilterFactory(object):
 
             return (parent_is_compound & parent_is_file & node_matches) \
                 | (parent_is_compound & parent_is_not_file & node_matches)
+
+    def create_compound_finder_filter(self, name, kind):
+        """Returns a filter which looks for a compound with the specified name and kind."""
+
+        node = Node()
+        return (node.node_type == 'compound') & (node.kind == kind)  & (node.name == name);
 
     def create_finder_filter(self, kind, name):
         """Returns a filter which looks for the compound node from the index which is a group node


### PR DESCRIPTION
The proposed PR replaces node stack with finder filter in directives as discussed in #151. As a side-effect this also removes some duplications in several `create_matcher_stack` methods which are no longer necessary and have been removed.