### PR TITLE
Render enums as "enum **name**" similarly to other symbols

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -332,12 +332,7 @@ class EnumMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
     def title(self):
 
-        if self.data_object.name.startswith("@"):
-            # Assume anonymous enum
-            return [self.node_factory.strong(text="Anonymous enum")]
-
-        name = self.node_factory.strong(text="%s enum" % self.data_object.name)
-        return [name]
+        return [self.node_factory.Text("enum ")] + MemberDefTypeSubRenderer.title(self)
 
     def description(self):
 

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -332,7 +332,13 @@ class EnumMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
     def title(self):
 
-        return [self.node_factory.Text("enum ")] + MemberDefTypeSubRenderer.title(self)
+        if self.data_object.name.startswith("@"):
+            # Assume anonymous enum
+            name = [self.node_factory.strong(text="[anonymous]")]
+        else:
+            name = MemberDefTypeSubRenderer.title(self)
+
+        return [self.node_factory.Text("enum ")] + name
 
     def description(self):
 


### PR DESCRIPTION
Fixes #158. This also keeps Doxygen names (`@id`) for an anonymous enums instead of replacing them with `Anonymous` as the latter can be confused for a real name since it is a valid identifier (however unlikely such name is used in practice). Perhaps it would be better to replace Doxygen name with something else which cannot be confused for an identifier (`/* anonymous */` ?) but I'm not sure.

There are other issues with enums which I'll report separately.