### PR TITLE
Return a node stack instead of a single node from finders

### DIFF
--- a/breathe/directive/file.py
+++ b/breathe/directive/file.py
@@ -48,7 +48,9 @@ class BaseFileDirective(BaseDirective):
             target_handler
             )
         node_list = []
-        for data_object in matches:
+        for node_stack in matches:
+
+            data_object = node_stack[0]
 
             renderer_factory = renderer_factory_creator.create_factory(
                 data_object,

--- a/breathe/finder/doxygen/compound.py
+++ b/breathe/finder/doxygen/compound.py
@@ -37,7 +37,7 @@ class CompoundDefTypeSubItemFinder(ItemFinder):
         node_stack = stack(self.data_object, ancestors)
 
         if filter_.allow(node_stack):
-            matches.append(self.data_object)
+            matches.append(node_stack)
 
         for sectiondef in self.data_object.sectiondef:
             finder = self.item_finder_factory.create_finder(sectiondef)
@@ -66,7 +66,7 @@ class SectionDefTypeSubItemFinder(ItemFinder):
         node_stack = stack(self.data_object, ancestors)
 
         if filter_.allow(node_stack):
-            matches.append(self.data_object)
+            matches.append(node_stack)
 
         for memberdef in self.data_object.memberdef:
             finder = self.item_finder_factory.create_finder(memberdef)
@@ -88,7 +88,7 @@ class MemberDefTypeSubItemFinder(ItemFinder):
         node_stack = stack(self.data_object, ancestors)
 
         if filter_.allow(node_stack):
-            matches.append(self.data_object)
+            matches.append(node_stack)
 
 
 class RefTypeSubItemFinder(ItemFinder):
@@ -98,5 +98,5 @@ class RefTypeSubItemFinder(ItemFinder):
         node_stack = stack(self.data_object, ancestors)
 
         if filter_.allow(node_stack):
-            matches.append(self.data_object)
+            matches.append(node_stack)
 

--- a/breathe/finder/doxygen/index.py
+++ b/breathe/finder/doxygen/index.py
@@ -79,7 +79,7 @@ class CompoundTypeSubItemFinder(ItemFinder):
 
         # Match against compound object
         if filter_.allow(node_stack):
-            matches.append(self.data_object)
+            matches.append(node_stack)
 
         # Descend to member children
         members = self.data_object.get_member()
@@ -97,8 +97,8 @@ class CompoundTypeSubItemFinder(ItemFinder):
             file_data = self.compound_parser.parse(self.data_object.refid)
             finder = self.item_finder_factory.create_finder(file_data)
 
-            for member_data in member_matches:
-                ref_filter = self.filter_factory.create_id_filter('memberdef', member_data.refid)
+            for member_stack in member_matches:
+                ref_filter = self.filter_factory.create_id_filter('memberdef', member_stack[0].refid)
                 finder.filter_(node_stack, ref_filter, matches)
 
         else:
@@ -125,6 +125,6 @@ class MemberTypeSubItemFinder(ItemFinder):
 
         # Match against member object
         if filter_.allow(node_stack):
-            matches.append(self.data_object)
+            matches.append(node_stack)
 
 


### PR DESCRIPTION
We may need a full node stack later to get a fully qualified name such as
a::b::C. The node itself usually does not contain the namespace information
so a full traversal of a node stack is required.
