### PR TITLE
Propagate node stack to renderers and fix links to typedefs in classes

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -62,7 +62,7 @@ class BaseDirective(rst.Directive):
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
 
-    def render(self, data_object, project_info, options, filter_, target_handler, mask_factory):
+    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
         "Standard render process used by subclasses"
 
         renderer_factory_creator = self.renderer_factory_creator_constructor.create_factory_creator(
@@ -74,7 +74,7 @@ class BaseDirective(rst.Directive):
 
         try:
             renderer_factory = renderer_factory_creator.create_factory(
-                data_object,
+                node_stack[0],
                 self.state,
                 self.state.document,
                 filter_,
@@ -86,7 +86,7 @@ class BaseDirective(rst.Directive):
         except FileIOError as e:
             return format_parser_error("doxygenclass", e.error, e.filename, self.state, self.lineno)
 
-        context = RenderContext([data_object, self.root_data_object], mask_factory)
+        context = RenderContext(node_stack, mask_factory)
         object_renderer = renderer_factory.create_renderer(context)
         node_list = object_renderer.render()
 
@@ -135,6 +135,6 @@ class DoxygenBaseDirective(BaseDirective):
         filter_ = self.filter_factory.create_outline_filter(self.options)
 
         mask_factory = NullMaskFactory()
-        return self.render(data_object, project_info, self.options, filter_, target_handler,
-                           mask_factory)
+        return self.render([data_object, self.root_data_object], project_info, self.options,
+                           filter_, target_handler, mask_factory)
 

--- a/breathe/directive/file.py
+++ b/breathe/directive/file.py
@@ -50,10 +50,8 @@ class BaseFileDirective(BaseDirective):
         node_list = []
         for node_stack in matches:
 
-            data_object = node_stack[0]
-
             renderer_factory = renderer_factory_creator.create_factory(
-                data_object,
+                node_stack[0],
                 self.state,
                 self.state.document,
                 filter_,
@@ -61,7 +59,7 @@ class BaseFileDirective(BaseDirective):
                 )
 
             mask_factory = NullMaskFactory()
-            context = RenderContext([data_object, self.root_data_object], mask_factory)
+            context = RenderContext(node_stack, mask_factory)
             object_renderer = renderer_factory.create_renderer(context)
             node_list.extend(object_renderer.render())
 

--- a/breathe/directive/file.py
+++ b/breathe/directive/file.py
@@ -3,10 +3,9 @@ from ..renderer.rst.doxygen.base import RenderContext
 from ..renderer.rst.doxygen.mask import NullMaskFactory
 from ..directive.base import BaseDirective
 from ..project import ProjectError
-from .base import WarningHandler, create_warning
+from .base import create_warning
 
 from docutils.parsers.rst.directives import unchanged_required, flag
-from docutils import nodes
 
 
 class BaseFileDirective(BaseDirective):

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -142,7 +142,7 @@ class DoxygenFunctionDirective(BaseDirective):
             )
 
         try:
-            data_object = self.resolve_function(matches, args, project_info)[0]
+            node_stack = self.resolve_function(matches, args, project_info)
         except NoMatchingFunctionError:
             return warning.warn('doxygenfunction: Cannot find function "{namespace}{function}" '
                                 '{tail}')
@@ -184,7 +184,7 @@ class DoxygenFunctionDirective(BaseDirective):
         filter_ = self.filter_factory.create_outline_filter(self.options)
 
         mask_factory = NullMaskFactory()
-        return self.render(data_object, project_info, self.options, filter_, target_handler,
+        return self.render(node_stack, project_info, self.options, filter_, target_handler,
                            mask_factory)
 
     def parse_args(self, function_description):
@@ -249,7 +249,7 @@ class DoxygenFunctionDirective(BaseDirective):
                 )
             filter_ = self.filter_factory.create_outline_filter(text_options)
             mask_factory = MaskFactory({'param': NoParameterNamesMask})
-            nodes = self.render(entry[0], project_info, text_options, filter_, target_handler,
+            nodes = self.render(entry, project_info, text_options, filter_, target_handler,
                                 mask_factory)
 
             # Render the nodes to text
@@ -327,8 +327,8 @@ class DoxygenClassLikeDirective(BaseDirective):
         filter_ = self.filter_factory.create_class_filter(name, self.options)
 
         mask_factory = NullMaskFactory()
-        return self.render(data_object, project_info, self.options, filter_, target_handler,
-                           mask_factory)
+        return self.render([data_object, self.root_data_object], project_info, self.options,
+                           filter_, target_handler, mask_factory)
 
 
 class DoxygenClassDirective(DoxygenClassLikeDirective):
@@ -503,7 +503,7 @@ class DoxygenBaseItemDirective(BaseDirective):
 
         node_stack = matches[0]
         mask_factory = NullMaskFactory()
-        return self.render(node_stack[0], project_info, self.options, filter_, target_handler, mask_factory)
+        return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
 
 
 class DoxygenVariableDirective(DoxygenBaseItemDirective):

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -123,6 +123,12 @@ class CppDomainHandler(DomainHandler):
             if (node.node_type == 'compound' and node.kind != 'file') or \
                 node.node_type == 'memberdef':
                 names.insert(0, node.name)
+            if (node.node_type == 'compounddef' and node.kind == 'namespace'):
+                # Nested namespaces include there parent namespace in there compoundname. ie,
+                # compoundname is 'foo::bar' instead of just 'bar' for namespace 'bar' nested in
+                # namespace 'foo'. But our node_stack includes 'foo' so we only want 'bar' at
+                # this point.
+                names.insert(0, node.compoundname.split('::')[-1])
 
         return '::'.join(names)
 

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -120,8 +120,14 @@ class CppDomainHandler(DomainHandler):
 
         names = []
         for node in node_stack:
-            if (node.node_type == 'compound' and node.kind != 'file') or \
+            if (node.node_type == 'compound' and node.kind not in ['file', 'namespace']) or \
                 node.node_type == 'memberdef':
+                # We skip the 'file' entries because the file name doesn't form part of the
+                # qualified name for the identifier. We skip the 'namespace' entries because if we
+                # find an object through the namespace 'compound' entry in the index.xml then we'll
+                # also have the 'compounddef' entry in our node stack and we'll get it from that. We
+                # need the 'compounddef' entry because if we find the object through the 'file'
+                # entry in the index.xml file then we need to get the namespace name from somewhere
                 names.insert(0, node.name)
             if (node.node_type == 'compounddef' and node.kind == 'namespace'):
                 # Nested namespaces include there parent namespace in there compoundname. ie,

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -120,9 +120,8 @@ class CppDomainHandler(DomainHandler):
 
         names = []
         for node in node_stack:
-            if node.node_type == 'compounddef':
-                names.insert(0, node.compoundname)
-            elif node.node_type == 'memberdef':
+            if (node.node_type == 'compound' and node.kind != 'file') or \
+                node.node_type == 'memberdef':
                 names.insert(0, node.name)
 
         return '::'.join(names)

--- a/documentation/source/typedef.rst
+++ b/documentation/source/typedef.rst
@@ -16,6 +16,7 @@ It produces this output:
 
 .. doxygentypedef:: UINT32
   :project: structcmd
+  :no-link:
 
 Example with Namespace
 ----------------------


### PR DESCRIPTION
This finally fixes issue #151 for typedefs (but not for classes).

BTW what is the purpose of `DoxygenBaseDirective`? I noticed that I hadn't updated it to use filters instead of matchers, but it turned out that it is not used anywhere. Is it something obsolete in which case wouldn't it better to remove it to avoid confusion?