### PR TITLE
Links to nested classes

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -47,14 +47,12 @@ def create_warning(project_info, state, lineno, **kwargs):
 class BaseDirective(rst.Directive):
 
     def __init__(self, root_data_object, renderer_factory_creator_constructor, finder_factory,
-                 matcher_factory, project_info_factory, filter_factory, target_handler_factory,
-                 *args):
+                 project_info_factory, filter_factory, target_handler_factory, *args):
         rst.Directive.__init__(self, *args)
 
         self.root_data_object = root_data_object
         self.renderer_factory_creator_constructor = renderer_factory_creator_constructor
         self.finder_factory = finder_factory
-        self.matcher_factory = matcher_factory
         self.project_info_factory = project_info_factory
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory

--- a/breathe/finder/core.py
+++ b/breathe/finder/core.py
@@ -7,10 +7,6 @@ class MultipleMatchesError(FinderError):
     pass
 
 
-class NoMatchesError(FinderError):
-    pass
-
-
 class FakeParentNode(object):
 
     node_type = "fakeparent"
@@ -34,20 +30,6 @@ class Finder(object):
 
         item_finder = self.item_finder_factory.create_finder(self._root)
         item_finder.filter_([FakeParentNode()], filter_, matches)
-
-    def find_one(self, matcher_stack):
-
-        results = self.find(matcher_stack)
-
-        count = len(results)
-        if count == 1:
-            return results[0]
-        elif count > 1:
-            # Multiple matches can easily happen as same thing
-            # can be present in both file and group sections
-            return results[0]
-        elif count < 1:
-            raise NoMatchesError(matcher_stack)
 
     def root(self):
 

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -862,6 +862,7 @@ class IncTypeSubRenderer(Renderer):
 
         return [self.node_factory.emphasis(text=text)]
 
+
 class RefTypeSubRenderer(Renderer):
 
     def __init__(self, compound_parser, *args):
@@ -894,7 +895,7 @@ class RefTypeSubRenderer(Renderer):
                 child_nodes,
                 self.renderer_factory,
                 self.node_factory,
-                self.domain_handler.create_inner_class_target(self.data_object),
+                self.domain_handler.create_inner_ref_target(self.data_object),
                 self.target_handler.create_target(refid),
                 self.state.document
                 )

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -894,7 +894,7 @@ class RefTypeSubRenderer(Renderer):
                 child_nodes,
                 self.renderer_factory,
                 self.node_factory,
-                [], # No domain reference
+                self.domain_handler.create_inner_class_target(self.data_object),
                 self.target_handler.create_target(refid),
                 self.state.document
                 )

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -72,6 +72,9 @@ class NullDomainHandler(DomainHandler):
     def create_class_target(self, data_object):
         return []
 
+    def create_inner_class_target(self, data_object):
+        return []
+
     def create_typedef_target(self, node_stack):
         return []
 
@@ -153,6 +156,12 @@ class CppDomainHandler(DomainHandler):
         name = data_object.name
 
         return self._create_target(name, "class", id_)
+
+    def create_inner_class_target(self, data_object):
+        """Creates a target for a class defined in another class."""
+
+        name = data_object.content_[0].getValue()
+        return self._create_target(name, "class", name)
 
     def create_typedef_target(self, node_stack):
 

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -158,7 +158,16 @@ class CppDomainHandler(DomainHandler):
         return self._create_target(name, "class", id_)
 
     def create_inner_ref_target(self, data_object):
-        """Creates a target for a class or namespace defined in another class or namespace."""
+        """Creates a target for a class or namespace defined in another class or namespace. This
+        will get called for any 'refType' node which includes a number of doxygen documentation
+        nodes like 'innerpage' & 'innergroup'. So we return nothing unless it is a class or
+        namespace.
+
+        See breathe.parser.doxygen.compoundsuper:compounddefType.buildChildren for the full list.
+        """
+
+        if data_object.node_name not in ['innerclass', 'innernamespace']:
+            return []
 
         # Extract fully qualified name (OuterClass::InnerClass) from node with xml like:
         #    <innerclass refid="..." prot="public">OuterClass::InnerClass</innerclass>

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -72,7 +72,7 @@ class NullDomainHandler(DomainHandler):
     def create_class_target(self, data_object):
         return []
 
-    def create_inner_class_target(self, data_object):
+    def create_inner_ref_target(self, data_object):
         return []
 
     def create_typedef_target(self, node_stack):
@@ -157,9 +157,11 @@ class CppDomainHandler(DomainHandler):
 
         return self._create_target(name, "class", id_)
 
-    def create_inner_class_target(self, data_object):
-        """Creates a target for a class defined in another class."""
+    def create_inner_ref_target(self, data_object):
+        """Creates a target for a class or namespace defined in another class or namespace."""
 
+        # Extract fully qualified name (OuterClass::InnerClass) from node with xml like:
+        #    <innerclass refid="..." prot="public">OuterClass::InnerClass</innerclass>
         name = data_object.content_[0].getValue()
         return self._create_target(name, "class", name)
 

--- a/breathe/renderer/rst/doxygen/domain.py
+++ b/breathe/renderer/rst/doxygen/domain.py
@@ -169,10 +169,15 @@ class CppDomainHandler(DomainHandler):
         if data_object.node_name not in ['innerclass', 'innernamespace']:
             return []
 
+        # Drop 'inner' to get 'class' or 'namespace'. Sphinx does support 'namespace' types in the
+        # cpp domain yet but we'll do this properly for the moment and correct it or updated Sphinx
+        # if needed
+        type_ = data_object.node_name.replace('inner', '')
+
         # Extract fully qualified name (OuterClass::InnerClass) from node with xml like:
         #    <innerclass refid="..." prot="public">OuterClass::InnerClass</innerclass>
         name = data_object.content_[0].getValue()
-        return self._create_target(name, "class", name)
+        return self._create_target(name, type_, name)
 
     def create_typedef_target(self, node_stack):
 

--- a/documentation/source/domains.rst
+++ b/documentation/source/domains.rst
@@ -35,6 +35,27 @@ which renders as :cpp:class:`testnamespace::NamespacedClassTest`, or using::
    
 which renders as: :cpp:class:`another reference <testnamespace::NamespacedClassTest>`.
 
+Inner Class Example
+-------------------
+
+Given the following Breathe directive::
+
+   .. doxygenclass:: OuterClass
+      :path: ../../examples/specific/class/xml
+      :members:
+
+Which create formatted output like:
+
+   .. doxygenclass:: OuterClass
+      :path: ../../examples/specific/class/xml
+      :members:
+
+We can refer to **OuterClass::InnerClass** using::
+
+   :cpp:class:`OuterClass::InnerClass`
+   
+which renders as :cpp:class:`OuterClass::InnerClass`.
+
 Function Examples
 -----------------
 

--- a/examples/specific/class.h
+++ b/examples/specific/class.h
@@ -11,10 +11,10 @@ public:
 
     static void functionS();
 
-    explicit NamespacedClassTest() {};
+    explicit NamespacedClassTest() {}
 
     //! \brief namespaced class other function
-    void anotherFunction() {};
+    void anotherFunction() {}
 };
 
 
@@ -24,15 +24,15 @@ class ClassTest {
 public:
 
     //! \brief second namespaced class function
-    void function() {};
+    void function() {}
 
     //! \brief second namespaced class other function
-    void anotherFunction() {};
+    void anotherFunction() {}
 
 };
 
 
-};;
+}
 
 //! \brief class outside of namespace
 class OuterClass {
@@ -77,9 +77,9 @@ public:
 protected:
 
     //! A protected function
-    void protectedFunction() {};
+    void protectedFunction() {}
 
-    void undocumentedProtectedFunction() {};
+    void undocumentedProtectedFunction() {}
 
     //! A protected class
     class ProtectedClass {};

--- a/examples/specific/class.h
+++ b/examples/specific/class.h
@@ -34,6 +34,16 @@ public:
 
 };;
 
+//! \brief class outside of namespace
+class OuterClass {
+
+public:
+
+    //! \brief inner class
+    class InnerClass {};
+
+};
+
 
 //! \brief class outside of namespace
 class ClassTest {


### PR DESCRIPTION
The proposed PR fixes linking to inner classes (#151) from RST and removes unused `DoxygenBaseDirective` class. I also took the liberty of cleaning up `examples/specific/class.h` a bit by removing unnecessary semicolons. Hope you don't mind.

Also now that all the directives use filters instead of matchers, [matcher.py](https://github.com/michaeljones/breathe/blob/master/breathe/finder/doxygen/matcher.py) may no longer be needed and could probably be removed. I haven't done it though in case you want to keep it for some reason.