### PR TITLE
Sphinx 1.3 support

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -57,7 +57,7 @@ class BaseDirective:
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
 
-    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
+    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
         "Standard render process used by subclasses"
 
         renderer_factory_creator = self.renderer_factory_creator_constructor.create_factory_creator(
@@ -83,6 +83,6 @@ class BaseDirective:
 
         context = RenderContext(node_stack, mask_factory)
         object_renderer = renderer_factory.create_renderer(context)
-        node_list = object_renderer.render()
+        node_list = object_renderer.render(node)
 
         return node_list

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -47,9 +47,9 @@ def create_warning(project_info, state, lineno, **kwargs):
 class BaseDirective(rst.Directive):
 
     def __init__(self, root_data_object, renderer_factory_creator_constructor, finder_factory,
-                 project_info_factory, filter_factory, target_handler_factory, *args, **kwargs):
-        directive_class = kwargs.get("directive", rst.Directive)
-        self.directive = directive_class(*args)
+                 project_info_factory, filter_factory, target_handler_factory, domain_directive_factory, *args):
+        rst.Directive.__init__(self, *args)
+        self.directive_args = args
 
         self.root_data_object = root_data_object
         self.renderer_factory_creator_constructor = renderer_factory_creator_constructor
@@ -57,10 +57,7 @@ class BaseDirective(rst.Directive):
         self.project_info_factory = project_info_factory
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
-
-    def __getattr__(self, attr):
-        """Forward getattr to the main directive."""
-        return getattr(self.directive, attr)
+        self.domain_directive_factory = domain_directive_factory
 
     def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
         "Standard render process used by subclasses"

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -47,7 +47,7 @@ def create_warning(project_info, state, lineno, **kwargs):
 class BaseDirective(rst.Directive):
 
     def __init__(self, root_data_object, renderer_factory_creator_constructor, finder_factory,
-                 project_info_factory, filter_factory, target_handler_factory, domain_directive_factory, *args):
+                 project_info_factory, filter_factory, target_handler_factory, domain_directive_factories, *args):
         rst.Directive.__init__(self, *args)
         self.directive_args = args
 
@@ -57,7 +57,7 @@ class BaseDirective(rst.Directive):
         self.project_info_factory = project_info_factory
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
-        self.domain_directive_factory = domain_directive_factory
+        self.domain_directive_factories = domain_directive_factories
 
     def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
         "Standard render process used by subclasses"

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -4,6 +4,7 @@ from ..renderer.rst.doxygen import format_parser_error
 from ..parser import ParserError, FileIOError
 
 from docutils import nodes
+from docutils.parsers import rst
 
 
 class WarningHandler(object):
@@ -43,12 +44,12 @@ def create_warning(project_info, state, lineno, **kwargs):
     return WarningHandler(state, context)
 
 
-class BaseDirective:
+class BaseDirective(rst.Directive):
 
     def __init__(self, root_data_object, renderer_factory_creator_constructor, finder_factory,
-                 project_info_factory, filter_factory, target_handler_factory, *args):
-        # Initialize standard directive's (rst.Directive or its subclass) arguments.
-        self.init_standard_args(*args)
+                 project_info_factory, filter_factory, target_handler_factory, *args, **kwargs):
+        directive_class = kwargs.get("directive", rst.Directive)
+        self.directive = directive_class(*args)
 
         self.root_data_object = root_data_object
         self.renderer_factory_creator_constructor = renderer_factory_creator_constructor
@@ -56,6 +57,10 @@ class BaseDirective:
         self.project_info_factory = project_info_factory
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
+
+    def __getattr__(self, attr):
+        """Forward getattr to the main directive."""
+        return getattr(self.directive, attr)
 
     def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
         "Standard render process used by subclasses"

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -3,7 +3,6 @@ from ..renderer.rst.doxygen.base import RenderContext
 from ..renderer.rst.doxygen import format_parser_error
 from ..parser import ParserError, FileIOError
 
-from docutils.parsers import rst
 from docutils import nodes
 
 
@@ -44,11 +43,12 @@ def create_warning(project_info, state, lineno, **kwargs):
     return WarningHandler(state, context)
 
 
-class BaseDirective(rst.Directive):
+class BaseDirective:
 
     def __init__(self, root_data_object, renderer_factory_creator_constructor, finder_factory,
                  project_info_factory, filter_factory, target_handler_factory, *args):
-        rst.Directive.__init__(self, *args)
+        # Initialize standard directive's (rst.Directive or its subclass) arguments.
+        self.init_standard_args(*args)
 
         self.root_data_object = root_data_object
         self.renderer_factory_creator_constructor = renderer_factory_creator_constructor

--- a/breathe/directive/file.py
+++ b/breathe/directive/file.py
@@ -6,9 +6,10 @@ from ..project import ProjectError
 from .base import create_warning
 
 from docutils.parsers.rst.directives import unchanged_required, flag
+from docutils.parsers import rst
 
 
-class BaseFileDirective(BaseDirective):
+class BaseFileDirective(BaseDirective, rst.Directive):
     """Base class handle the main work when given the appropriate file and project info to work
     from.
     """
@@ -16,6 +17,9 @@ class BaseFileDirective(BaseDirective):
     # We use inheritance here rather than a separate object and composition, because so much
     # information is present in the Directive class from the docutils framework that we'd have to
     # pass way too much stuff to a helper object to be reasonable.
+
+    def init_standard_args(self, *args):
+        rst.Directive.__init__(self, *args)
 
     def handle_contents(self, file_, project_info):
 

--- a/breathe/directive/file.py
+++ b/breathe/directive/file.py
@@ -9,7 +9,7 @@ from docutils.parsers.rst.directives import unchanged_required, flag
 from docutils.parsers import rst
 
 
-class BaseFileDirective(BaseDirective, rst.Directive):
+class BaseFileDirective(BaseDirective):
     """Base class handle the main work when given the appropriate file and project info to work
     from.
     """
@@ -17,9 +17,6 @@ class BaseFileDirective(BaseDirective, rst.Directive):
     # We use inheritance here rather than a separate object and composition, because so much
     # information is present in the Directive class from the docutils framework that we'd have to
     # pass way too much stuff to a helper object to be reasonable.
-
-    def init_standard_args(self, *args):
-        rst.Directive.__init__(self, *args)
 
     def handle_contents(self, file_, project_info):
 

--- a/breathe/directive/index.py
+++ b/breathe/directive/index.py
@@ -5,19 +5,22 @@ from ..renderer.rst.doxygen import format_parser_error
 from ..directive.base import BaseDirective
 from ..project import ProjectError
 from ..parser import ParserError, FileIOError
-from .base import WarningHandler, create_warning
+from .base import create_warning
 
+from docutils.parsers import rst
 from docutils.parsers.rst.directives import unchanged_required, flag
-from docutils import nodes
 
 
-class BaseIndexDirective(BaseDirective):
+class BaseIndexDirective(BaseDirective, rst.Directive):
     """Base class handle the main work when given the appropriate project info to work from.
     """
 
     # We use inheritance here rather than a separate object and composition, because so much
     # information is present in the Directive class from the docutils framework that we'd have to
     # pass way too much stuff to a helper object to be reasonable.
+
+    def init_standard_args(self, *args):
+        rst.Directive.__init__(self, *args)
 
     def handle_contents(self, project_info):
 

--- a/breathe/directive/index.py
+++ b/breathe/directive/index.py
@@ -11,16 +11,13 @@ from docutils.parsers import rst
 from docutils.parsers.rst.directives import unchanged_required, flag
 
 
-class BaseIndexDirective(BaseDirective, rst.Directive):
+class BaseIndexDirective(BaseDirective):
     """Base class handle the main work when given the appropriate project info to work from.
     """
 
     # We use inheritance here rather than a separate object and composition, because so much
     # information is present in the Directive class from the docutils framework that we'd have to
     # pass way too much stuff to a helper object to be reasonable.
-
-    def init_standard_args(self, *args):
-        rst.Directive.__init__(self, *args)
 
     def handle_contents(self, project_info):
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -323,10 +323,11 @@ class DoxygenClassLikeDirective(BaseDirective):
 
         mask_factory = NullMaskFactory()
         # Defer to domains specific directive.
-        # TODO: get domain
-        domain_directive = self.domain_directive_factories["cpp"].create_class_directive(*self.directive_args)
+        node_stack = matches[0]
+        domain = self.get_domain(node_stack, project_info)
+        domain_directive = self.domain_directive_factories[domain].create_class_directive(*self.directive_args)
         result = domain_directive.run()
-        self.render(matches[0], project_info, self.options, filter_, target_handler, mask_factory, result[1])
+        self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory, result[1])
         return result
 
 
@@ -596,7 +597,8 @@ class DoxygenDirectiveFactory(object):
 
     def __init__(self, node_factory, text_renderer, root_data_object,
                  renderer_factory_creator_constructor, finder_factory,
-                 project_info_factory, filter_factory, target_handler_factory, domain_directive_factories):
+                 project_info_factory, filter_factory, target_handler_factory,
+                 domain_directive_factories, parser_factory):
 
         self.node_factory = node_factory
         self.text_renderer = text_renderer
@@ -607,6 +609,7 @@ class DoxygenDirectiveFactory(object):
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
         self.domain_directive_factories = domain_directive_factories
+        self.parser_factory = parser_factory
 
     # TODO: This methods should be scrapped as they are only called in one place. We should just
     # inline the code at the call site
@@ -626,7 +629,8 @@ class DoxygenDirectiveFactory(object):
             self.project_info_factory,
             self.filter_factory,
             self.target_handler_factory,
-            self.domain_directive_factories
+            self.domain_directive_factories,
+            self.parser_factory
             )
 
     def create_struct_directive_container(self):
@@ -678,7 +682,8 @@ class DoxygenDirectiveFactory(object):
             self.project_info_factory,
             self.filter_factory,
             self.target_handler_factory,
-            self.domain_directive_factories
+            self.domain_directive_factories,
+            self.parser_factory
             )
 
     def get_config_values(self, app):
@@ -903,7 +908,8 @@ def setup(app):
         project_info_factory,
         filter_factory,
         target_handler_factory,
-        {"c": CDomainDirectiveFactory, "cpp": CPPDomainDirectiveFactory}
+        {"c": CDomainDirectiveFactory, "cpp": CPPDomainDirectiveFactory},
+        parser_factory
         )
 
     DoxygenFunctionDirective.app = app

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -19,7 +19,6 @@ from .project import ProjectInfoFactory, ProjectError
 
 from docutils.parsers.rst.directives import unchanged_required, unchanged, flag
 from docutils.statemachine import ViewList
-from docutils.parsers import rst
 from sphinx.domains import cpp
 from sphinx.writers.text import TextWriter
 from sphinx.builders.text import TextBuilder
@@ -79,7 +78,7 @@ class TextRenderer(object):
 # Directives
 # ----------
 
-class DoxygenFunctionDirective(BaseDirective, rst.Directive):
+class DoxygenFunctionDirective(BaseDirective):
 
     required_arguments = 1
     option_spec = {
@@ -96,9 +95,6 @@ class DoxygenFunctionDirective(BaseDirective, rst.Directive):
 
         self.node_factory = node_factory
         self.text_renderer = text_renderer
-
-    def init_standard_args(self, *args):
-        rst.Directive.__init__(self, *args)
 
     def run(self):
 
@@ -276,7 +272,7 @@ class DoxygenFunctionDirective(BaseDirective, rst.Directive):
         return node_stack
 
 
-class DoxygenClassLikeDirective(BaseDirective, cpp.CPPClassObject):
+class DoxygenClassLikeDirective(BaseDirective):
 
     required_arguments = 1
     optional_arguments = 0
@@ -294,8 +290,8 @@ class DoxygenClassLikeDirective(BaseDirective, cpp.CPPClassObject):
         }
     has_content = False
 
-    def init_standard_args(self, *args):
-        cpp.CPPClassObject.__init__(self, *args)
+    def __init__(self, *args):
+        BaseDirective.__init__(self, *args, directive=cpp.CPPClassObject)
 
     def run(self):
 
@@ -329,7 +325,7 @@ class DoxygenClassLikeDirective(BaseDirective, cpp.CPPClassObject):
         filter_ = self.filter_factory.create_class_filter(name, self.options)
 
         mask_factory = NullMaskFactory()
-        result = cpp.CPPClassObject.run(self)
+        result = self.directive.run()
         self.render(matches[0], project_info, self.options, filter_, target_handler, mask_factory, result[1])
         return result
 
@@ -344,7 +340,7 @@ class DoxygenStructDirective(DoxygenClassLikeDirective):
     kind = "struct"
 
 
-class DoxygenContentBlockDirective(BaseDirective, rst.Directive):
+class DoxygenContentBlockDirective(BaseDirective):
     """Base class for namespace and group directives which have very similar behaviours"""
 
     required_arguments = 1
@@ -361,9 +357,6 @@ class DoxygenContentBlockDirective(BaseDirective, rst.Directive):
         "no-link": flag
         }
     has_content = False
-
-    def init_standard_args(self, *args):
-        rst.Directive.__init__(self, *args)
 
     def run(self):
 
@@ -454,7 +447,7 @@ class DoxygenGroupDirective(DoxygenContentBlockDirective):
 # abstracted in a far nicer way to avoid repeating so much code
 #
 # Now we've removed the definition_list wrap so we really need to refactor this!
-class DoxygenBaseItemDirective(BaseDirective, rst.Directive):
+class DoxygenBaseItemDirective(BaseDirective):
 
     required_arguments = 1
     optional_arguments = 1
@@ -465,9 +458,6 @@ class DoxygenBaseItemDirective(BaseDirective, rst.Directive):
         "no-link": flag,
         }
     has_content = False
-
-    def init_standard_args(self, *args):
-        rst.Directive.__init__(self, *args)
 
     def create_finder_filter(self, namespace, name):
         """Creates a filter to find the node corresponding to this item."""

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -19,6 +19,7 @@ from .project import ProjectInfoFactory, ProjectError
 
 from docutils.parsers.rst.directives import unchanged_required, unchanged, flag
 from docutils.statemachine import ViewList
+from docutils.parsers import rst
 from sphinx.domains.cpp import DefinitionParser
 from sphinx.writers.text import TextWriter
 from sphinx.builders.text import TextBuilder
@@ -78,7 +79,7 @@ class TextRenderer(object):
 # Directives
 # ----------
 
-class DoxygenFunctionDirective(BaseDirective):
+class DoxygenFunctionDirective(BaseDirective, rst.Directive):
 
     required_arguments = 1
     option_spec = {
@@ -91,10 +92,13 @@ class DoxygenFunctionDirective(BaseDirective):
     final_argument_whitespace = True
 
     def __init__(self, node_factory, text_renderer, *args, **kwargs):
-        super(DoxygenFunctionDirective, self).__init__(*args, **kwargs)
+        BaseDirective.__init__(self, *args, **kwargs)
 
         self.node_factory = node_factory
         self.text_renderer = text_renderer
+
+    def init_standard_args(self, *args):
+        rst.Directive.__init__(self, *args)
 
     def run(self):
 
@@ -272,7 +276,7 @@ class DoxygenFunctionDirective(BaseDirective):
         return node_stack
 
 
-class DoxygenClassLikeDirective(BaseDirective):
+class DoxygenClassLikeDirective(BaseDirective, rst.Directive):
 
     required_arguments = 1
     optional_arguments = 0
@@ -289,6 +293,9 @@ class DoxygenClassLikeDirective(BaseDirective):
         "no-link": flag,
         }
     has_content = False
+
+    def init_standard_args(self, *args):
+        rst.Directive.__init__(self, *args)
 
     def run(self):
 
@@ -335,7 +342,7 @@ class DoxygenStructDirective(DoxygenClassLikeDirective):
     kind = "struct"
 
 
-class DoxygenContentBlockDirective(BaseDirective):
+class DoxygenContentBlockDirective(BaseDirective, rst.Directive):
     """Base class for namespace and group directives which have very similar behaviours"""
 
     required_arguments = 1
@@ -352,6 +359,9 @@ class DoxygenContentBlockDirective(BaseDirective):
         "no-link": flag
         }
     has_content = False
+
+    def init_standard_args(self, *args):
+        rst.Directive.__init__(self, *args)
 
     def run(self):
 
@@ -442,7 +452,7 @@ class DoxygenGroupDirective(DoxygenContentBlockDirective):
 # abstracted in a far nicer way to avoid repeating so much code
 #
 # Now we've removed the definition_list wrap so we really need to refactor this!
-class DoxygenBaseItemDirective(BaseDirective):
+class DoxygenBaseItemDirective(BaseDirective, rst.Directive):
 
     required_arguments = 1
     optional_arguments = 1
@@ -453,6 +463,9 @@ class DoxygenBaseItemDirective(BaseDirective):
         "no-link": flag,
         }
     has_content = False
+
+    def init_standard_args(self, *args):
+        rst.Directive.__init__(self, *args)
 
     def create_finder_filter(self, namespace, name):
         """Creates a filter to find the node corresponding to this item."""

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -165,9 +165,6 @@ class DoxygenToRstRendererFactory(object):
 
             class_ = indexrenderer.CompoundTypeSubRenderer
 
-            if data_object.kind == "class":
-                class_ = indexrenderer.ClassCompoundTypeSubRenderer
-
             # For compound node types Renderer is CreateCompoundTypeSubRenderer
             # as defined below. This could be cleaner
             return Renderer(

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -218,7 +218,7 @@ class MemberDefTypeSubRenderer(Renderer):
 
         return self.data_object.kind
 
-    def render(self):
+    def render(self, node=None):
 
         # Build targets for linking
         targets = []


### PR DESCRIPTION
The proposed PR implements preliminary support for Sphinx 1.3 and overall better integration with Sphinx. Instead of inheriting `BaseDirective` from `rst.Directive`, each individual directive class can now inherit from specific Sphinx class. For example, `DoxygenClassLikeDirective` inherits from `CPPClassObject` (currently this is the only class that is reused in such way).

This improves consistency with Sphinx output, allows reusing functionality of the cpp domain and reduces duplication - once implemented completely, there will be no need to create domain targets or signature nodes.

With this PR, I can now process `doxygenclass` directives both on Sphinx 1.2 and Sphinx 1.3 and the output looks more consistent with the output of other Sphinx directives including the ones from the cpp domain. For example, the signature line now shows a permalink anchor on hover:

![screenshot from 2015-02-02 16 29 48](https://cloud.githubusercontent.com/assets/576385/6012117/d87d5642-aaf8-11e4-8c64-d03c486415a2.png)


Although I made it a PR, I don't expect it to be merged yet. This is mostly to open a discussion, so comments are welcome =).
