### PR TITLE
Fix rendering of class templates

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -325,7 +325,8 @@ class DoxygenClassLikeDirective(BaseDirective):
         # Defer to domains specific directive.
         node_stack = matches[0]
         domain = self.get_domain(node_stack, project_info)
-        domain_directive = self.domain_directive_factories[domain].create_class_directive(*self.directive_args)
+        args = ('class',) + self.directive_args[1:]
+        domain_directive = self.domain_directive_factories[domain].create_class_directive(*args)
         result = domain_directive.run()
         self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory, result[1])
         return result

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -640,7 +640,7 @@ class DocParamListTypeSubRenderer(Renderer):
 
 
 class DocParamListItemSubRenderer(Renderer):
-    """ Paramter Description Renderer  """
+    """ Parameter Description Renderer  """
 
     def render(self):
 

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -54,9 +54,22 @@ class CompoundRenderer(Renderer):
         file_data = parent_context.node_stack[0]
         new_context = parent_context.create_child_context(file_data.compounddef)
 
+        # Check if there is template information and format it as desired
+        template_signode = None
+        if file_data.compounddef.templateparamlist:
+            context = new_context.create_child_context(file_data.compounddef.templateparamlist)
+            renderer = self.renderer_factory.create_renderer(context)
+            template_nodes = [self.node_factory.Text("template <")]
+            template_nodes.extend(renderer.render())
+            template_nodes.append(self.node_factory.Text(">"))
+            template_signode = self.node_factory.desc_signature()
+            template_signode.extend(template_nodes)
+
         if node:
-            node.children[0].insert(0, doxygen_target)
             contentnode = node.children[1]
+            if template_signode:
+                node.insert(0, template_signode)
+            node.children[0].insert(0, doxygen_target)
         else:
             # Build targets for linking
             targets = []
@@ -64,19 +77,9 @@ class CompoundRenderer(Renderer):
             targets.extend(doxygen_target)
 
             title_signode = self.node_factory.desc_signature()
-
-            # Check if there is template information and format it as desired
-            template_signode = None
-            if file_data.compounddef.templateparamlist:
-                context = new_context.create_child_context(file_data.compounddef.templateparamlist)
-                renderer = self.renderer_factory.create_renderer(context)
-                template_nodes = [self.node_factory.Text("template <")]
-                template_nodes.extend(renderer.render())
-                template_nodes.append(self.node_factory.Text(">"))
-                template_signode = self.node_factory.desc_signature()
+            if template_signode:
                 # Add targets to the template line if it is there
                 template_signode.extend(targets)
-                template_signode.extend(template_nodes)
             else:
                 # Add targets to title line if there is no template line
                 title_signode.extend(targets)

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -66,7 +66,10 @@ class CompoundRenderer(Renderer):
             template_signode.extend(template_nodes)
 
         if node:
-            contentnode = node.children[1]
+            signode, contentnode = node.children
+            # The cpp domain in Sphinx doesn't support structs at the moment, so change the text from "class "
+            # to the correct kind which can be "class " or "struct ".
+            signode[0].children[0] = self.node_factory.Text(kind + " ")
             if template_signode:
                 node.insert(0, template_signode)
             node.children[0].insert(0, doxygen_target)


### PR DESCRIPTION
This PR fixes a small regression with rendering of class templates that was introduced in https://github.com/michaeljones/breathe/pull/167 (sorry for that), namely missing `template <...>` lines.