### PR TITLE
Support for Sphinx 1.3 in doxygenfunction

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -50,7 +50,7 @@ class BaseDirective(rst.Directive):
                  project_info_factory, filter_factory, target_handler_factory, domain_directive_factories,
                  parser_factory, *args):
         rst.Directive.__init__(self, *args)
-        self.directive_args = args
+        self.directive_args = list(args)  # Convert tuple to list to allow modification.
 
         self.root_data_object = root_data_object
         self.renderer_factory_creator_constructor = renderer_factory_creator_constructor
@@ -116,7 +116,7 @@ class BaseDirective(rst.Directive):
         # Defer to domains specific directive.
         domain = self.get_domain(node_stack, project_info)
         # TODO: replace domain_directive_factories dictionary with an object
-        domain_directive = self.domain_directive_factories[domain].create(*self.directive_args)
+        domain_directive = self.domain_directive_factories[domain].create(self.directive_args)
         result = domain_directive.run()
         self.do_render(node_stack, project_info, options, filter_, target_handler, mask_factory, result[1])
         return result

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -82,7 +82,7 @@ class BaseDirective(rst.Directive):
             filename = BaseDirective.get_filename(file_data.compounddef)
         return project_info.domain_for_file(filename)
 
-    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
+    def do_render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
         "Standard render process used by subclasses"
 
         renderer_factory_creator = self.renderer_factory_creator_constructor.create_factory_creator(
@@ -111,3 +111,12 @@ class BaseDirective(rst.Directive):
         node_list = object_renderer.render(node)
 
         return node_list
+
+    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
+        # Defer to domains specific directive.
+        domain = self.get_domain(node_stack, project_info)
+        # TODO: replace domain_directive_factories dictionary with an object
+        domain_directive = self.domain_directive_factories[domain].create(*self.directive_args)
+        result = domain_directive.run()
+        self.do_render(node_stack, project_info, options, filter_, target_handler, mask_factory, result[1])
+        return result

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -117,6 +117,9 @@ class BaseDirective(rst.Directive):
         domain = self.get_domain(node_stack, project_info)
         # TODO: replace domain_directive_factories dictionary with an object
         domain_directive = self.domain_directive_factories[domain].create(self.directive_args)
+        # Translate Breathe's no-link option into the standard noindex option.
+        if 'no-link' in options:
+            domain_directive.options['noindex'] = True
         result = domain_directive.run()
         self.do_render(node_stack, project_info, options, filter_, target_handler, mask_factory, result[1])
         return result

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -185,7 +185,12 @@ class DoxygenFunctionDirective(BaseDirective):
         mask_factory = NullMaskFactory()
         # Get full function signature for the domain directive.
         node = node_stack[0]
-        self.directive_args[1] = [node.definition + node.argsstring]
+        signature = node.definition + node.argsstring
+        # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
+        virtual = 'virtual '
+        if signature.startswith(virtual):
+            signature = signature[len(virtual):]
+        self.directive_args[1] = [signature]
         return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
 
     def parse_args(self, function_description):

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -185,7 +185,13 @@ class DoxygenFunctionDirective(BaseDirective):
         mask_factory = NullMaskFactory()
         # Get full function signature for the domain directive.
         node = node_stack[0]
-        signature = node.definition + node.argsstring
+        params = []
+        for param in node.param:
+            param_type = param.type_.content_[0].value
+            if not isinstance(param_type, unicode):
+                param_type = param_type.valueOf_
+            params.append(param_type + ' ' + param.defname)
+        signature = '{}({})'.format(node.definition, ', '.join(params))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
         virtual = 'virtual '
         if signature.startswith(virtual):

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -183,8 +183,8 @@ class DoxygenFunctionDirective(BaseDirective):
         filter_ = self.filter_factory.create_outline_filter(self.options)
 
         mask_factory = NullMaskFactory()
-        return self.do_render(node_stack, project_info, self.options, filter_, target_handler,
-                              mask_factory)
+        # TODO: get full function signature
+        return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
 
     def parse_args(self, function_description):
         # Strip off trailing qualifiers
@@ -841,7 +841,8 @@ class CPPDomainDirectiveFactory:
     # A mapping from Breathe directive names to domain classes.
     classes = {
         'doxygenclass': cpp.CPPClassObject,
-        'doxygenstruct': cpp.CPPClassObject
+        'doxygenstruct': cpp.CPPClassObject,
+        'doxygenfunction': cpp.CPPFunctionObject
     }
 
     @staticmethod

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -838,16 +838,19 @@ class CDomainDirectiveFactory:
 
 
 class CPPDomainDirectiveFactory:
-    # A mapping from Breathe directive names to domain classes.
+    # A mapping from Breathe directive names to domain classes and directive names.
     classes = {
-        'doxygenclass': cpp.CPPClassObject,
-        'doxygenstruct': cpp.CPPClassObject,
-        'doxygenfunction': cpp.CPPFunctionObject
+        'doxygenclass': (cpp.CPPClassObject, 'class'),
+        'doxygenstruct': (cpp.CPPClassObject, 'class'),
+        'doxygenfunction': (cpp.CPPFunctionObject, 'function')
     }
 
     @staticmethod
     def create(*args):
-        cls = CPPDomainDirectiveFactory.classes.get(args[0], cpp.CPPObject)
+        cls, name = CPPDomainDirectiveFactory.classes.get(args[0], cpp.CPPObject)
+        # Replace the directive name because domain directives don't know how to handle
+        # Breathe's "doxygen" directives.
+        args = (name,) + args[1:]
         return cls(*args)
 
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -190,7 +190,7 @@ class DoxygenFunctionDirective(BaseDirective):
             param_type = param.type_.content_[0].value
             if not isinstance(param_type, unicode):
                 param_type = param_type.valueOf_
-            params.append(param_type + ' ' + param.defname)
+            params.append(param_type + ' ' + param.declname)
         signature = '{0}({1})'.format(node.definition, ', '.join(params))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
         virtual = 'virtual '

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -183,7 +183,9 @@ class DoxygenFunctionDirective(BaseDirective):
         filter_ = self.filter_factory.create_outline_filter(self.options)
 
         mask_factory = NullMaskFactory()
-        # TODO: get full function signature
+        # Get full function signature for the domain directive.
+        node = node_stack[0]
+        self.directive_args[1] = [node.definition + node.argsstring]
         return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
 
     def parse_args(self, function_description):
@@ -833,7 +835,7 @@ class FileStateCache(object):
 
 class CDomainDirectiveFactory:
     @staticmethod
-    def create(*args):
+    def create(args):
         return c.CObject(*args)
 
 
@@ -846,11 +848,11 @@ class CPPDomainDirectiveFactory:
     }
 
     @staticmethod
-    def create(*args):
+    def create(args):
         cls, name = CPPDomainDirectiveFactory.classes.get(args[0], cpp.CPPObject)
         # Replace the directive name because domain directives don't know how to handle
         # Breathe's "doxygen" directives.
-        args = (name,) + args[1:]
+        args[0] = name
         return cls(*args)
 
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -190,7 +190,7 @@ class DoxygenFunctionDirective(BaseDirective):
             param_type = param.type_.content_[0].value
             if not isinstance(param_type, unicode):
                 param_type = param_type.valueOf_
-            params.append(param_type + ' ' + param.declname)
+            params.append(param_type + ' ' + (param.defname if param.defname else param.declname))
         signature = '{0}({1})'.format(node.definition, ', '.join(params))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
         virtual = 'virtual '

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -183,8 +183,8 @@ class DoxygenFunctionDirective(BaseDirective):
         filter_ = self.filter_factory.create_outline_filter(self.options)
 
         mask_factory = NullMaskFactory()
-        return self.render(node_stack, project_info, self.options, filter_, target_handler,
-                           mask_factory)
+        return self.do_render(node_stack, project_info, self.options, filter_, target_handler,
+                              mask_factory)
 
     def parse_args(self, function_description):
         # Strip off trailing qualifiers
@@ -248,8 +248,8 @@ class DoxygenFunctionDirective(BaseDirective):
                 )
             filter_ = self.filter_factory.create_outline_filter(text_options)
             mask_factory = MaskFactory({'param': NoParameterNamesMask})
-            nodes = self.render(entry, project_info, text_options, filter_, target_handler,
-                                mask_factory)
+            nodes = self.do_render(entry, project_info, text_options, filter_, target_handler,
+                                   mask_factory)
 
             # Render the nodes to text
             signature = self.text_renderer.render(nodes, self.state.document)
@@ -322,14 +322,7 @@ class DoxygenClassLikeDirective(BaseDirective):
         filter_ = self.filter_factory.create_class_filter(name, self.options)
 
         mask_factory = NullMaskFactory()
-        # Defer to domains specific directive.
-        node_stack = matches[0]
-        domain = self.get_domain(node_stack, project_info)
-        args = ('class',) + self.directive_args[1:]
-        domain_directive = self.domain_directive_factories[domain].create_class_directive(*args)
-        result = domain_directive.run()
-        self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory, result[1])
-        return result
+        return self.render(matches[0], project_info, self.options, filter_, target_handler, mask_factory)
 
 
 class DoxygenClassDirective(DoxygenClassLikeDirective):
@@ -504,7 +497,7 @@ class DoxygenBaseItemDirective(BaseDirective):
 
         node_stack = matches[0]
         mask_factory = NullMaskFactory()
-        return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
+        return self.do_render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
 
 
 class DoxygenVariableDirective(DoxygenBaseItemDirective):
@@ -840,14 +833,21 @@ class FileStateCache(object):
 
 class CDomainDirectiveFactory:
     @staticmethod
-    def create_class_directive(*args):
+    def create(*args):
         return c.CObject(*args)
 
 
 class CPPDomainDirectiveFactory:
+    # A mapping from Breathe directive names to domain classes.
+    classes = {
+        'doxygenclass': cpp.CPPClassObject,
+        'doxygenstruct': cpp.CPPClassObject
+    }
+
     @staticmethod
-    def create_class_directive(*args):
-        return cpp.CPPClassObject(*args)
+    def create(*args):
+        cls = CPPDomainDirectiveFactory.classes.get(args[0], cpp.CPPObject)
+        return cls(*args)
 
 
 # Setup

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -191,7 +191,7 @@ class DoxygenFunctionDirective(BaseDirective):
             if not isinstance(param_type, unicode):
                 param_type = param_type.valueOf_
             params.append(param_type + ' ' + param.defname)
-        signature = '{}({})'.format(node.definition, ', '.join(params))
+        signature = '{0}({1})'.format(node.definition, ', '.join(params))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
         virtual = 'virtual '
         if signature.startswith(virtual):

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -26,7 +26,7 @@ class Renderer(object):
         """Creates a node for the ``template <...>`` part of the declaration represented by object."""
         if not object.templateparamlist:
             return None
-        context = self.context.create_child_context(self.data_object.templateparamlist)
+        context = self.context.create_child_context(object.templateparamlist)
         renderer = self.renderer_factory.create_renderer(context)
         nodes = [self.node_factory.Text("template <")]
         nodes.extend(renderer.render())

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -22,15 +22,15 @@ class Renderer(object):
         self.domain_handler = domain_handler
         self.target_handler = target_handler
 
-    def create_template_node(self, object):
-        """Creates a node for the ``template <...>`` part of the declaration represented by object."""
-        if not object.templateparamlist:
+    def create_template_node(self, decl):
+        """Creates a node for the ``template <...>`` part of the declaration."""
+        if not decl.templateparamlist:
             return None
-        context = self.context.create_child_context(object.templateparamlist)
+        context = self.context.create_child_context(decl.templateparamlist)
         renderer = self.renderer_factory.create_renderer(context)
         nodes = [self.node_factory.Text("template <")]
         nodes.extend(renderer.render())
-        nodes.append(self.node_factory.Text("> "))
+        nodes.append(self.node_factory.Text(">"))
         signode = self.node_factory.desc_signature()
         signode.extend(nodes)
         return signode

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -22,6 +22,19 @@ class Renderer(object):
         self.domain_handler = domain_handler
         self.target_handler = target_handler
 
+    def create_template_node(self, object):
+        """Creates a node for the ``template <...>`` part of the declaration represented by object."""
+        if not object.templateparamlist:
+            return None
+        context = self.context.create_child_context(self.data_object.templateparamlist)
+        renderer = self.renderer_factory.create_renderer(context)
+        nodes = [self.node_factory.Text("template <")]
+        nodes.extend(renderer.render())
+        nodes.append(self.node_factory.Text("> "))
+        signode = self.node_factory.desc_signature()
+        signode.extend(nodes)
+        return signode
+
 
 class RenderContext(object):
 

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -283,7 +283,8 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         title_node = self.node_factory.desc_signature()
         title_node.extend(self.title())
         signodes.append(title_node)
-        signodes[0].extend(targets)
+        for target in reversed(targets):
+            signodes[0].insert(0, target)
         return signodes
 
     def title(self):

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -278,28 +278,12 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
     def build_signodes(self, targets):
 
-        signodes = []
-        title_signode = self.node_factory.desc_signature()
-
-        # Handle any template information
-        if self.data_object.templateparamlist:
-            context = self.context.create_child_context(self.data_object.templateparamlist)
-            renderer = self.renderer_factory.create_renderer(context)
-            template_nodes = [self.node_factory.Text("template <")]
-            template_nodes.extend(renderer.render())
-            template_nodes.append(self.node_factory.Text("> "))
-            template_signode = self.node_factory.desc_signature()
-            # Add targets to the template line if it is there
-            template_signode.extend(targets)
-            template_signode.extend(template_nodes)
-            signodes.append(template_signode)
-
-        else:
-            # Add targets to title line if there is no template line
-            title_signode.extend(targets)
-
-        title_signode.extend(self.title())
-        signodes.append(title_signode)
+        template_node = self.create_template_node(self.data_object)
+        signodes = [template_node] if template_node else []
+        title_node = self.node_factory.desc_signature()
+        title_node.extend(self.title())
+        signodes.append(title_node)
+        signodes[0].extend(targets)
         return signodes
 
     def title(self):

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -223,7 +223,7 @@ class MemberDefTypeSubRenderer(Renderer):
         doxygen_target = self.create_doxygen_target()
         if node:
             signode, contentnode = node.children
-            if self.data_object.virt:
+            if self.data_object.virt != 'non-virtual':
                 signode.insert(0, self.node_factory.Text("virtual "))
             signode.insert(0, doxygen_target)
         else:

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -222,8 +222,10 @@ class MemberDefTypeSubRenderer(Renderer):
 
         doxygen_target = self.create_doxygen_target()
         if node:
-            node.children[0].insert(0, doxygen_target)
-            contentnode = node.children[1]
+            signode, contentnode = node.children
+            if self.data_object.virt:
+                signode.insert(0, self.node_factory.Text("virtual "))
+            signode.insert(0, doxygen_target)
         else:
             # Build targets for linking
             targets = []

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -220,23 +220,28 @@ class MemberDefTypeSubRenderer(Renderer):
 
     def render(self, node=None):
 
-        # Build targets for linking
-        targets = []
-        targets.extend(self.create_domain_target())
-        targets.extend(self.create_doxygen_target())
+        doxygen_target = self.create_doxygen_target()
+        if node:
+            node.children[0].insert(0, doxygen_target)
+            contentnode = node.children[1]
+        else:
+            # Build targets for linking
+            targets = []
+            targets.extend(self.create_domain_target())
+            targets.extend(doxygen_target)
 
-        signodes = self.build_signodes(targets)
+            signodes = self.build_signodes(targets)
 
-        # Build description nodes
-        contentnode = self.node_factory.desc_content()
+            # Build description nodes
+            contentnode = self.node_factory.desc_content()
+
+            node = self.node_factory.desc()
+            node.document = self.state.document
+            node['objtype'] = self.objtype()
+            node.extend(signodes)
+            node.append(contentnode)
+
         contentnode.extend(self.description())
-
-        node = self.node_factory.desc()
-        node.document = self.state.document
-        node['objtype'] = self.objtype()
-        node.extend(signodes)
-        node.append(contentnode)
-
         return [node]
 
 

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -306,6 +306,14 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         self.add_qualifiers(nodes)
         return nodes
 
+    def render(self, node=None):
+        result = MemberDefTypeSubRenderer.render(self, node)
+        if node:
+            template_node = self.create_template_node(self.data_object)
+            if template_node:
+                node.insert(0, template_node)
+        return result
+
 
 class DefineMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -55,15 +55,7 @@ class CompoundRenderer(Renderer):
         new_context = parent_context.create_child_context(file_data.compounddef)
 
         # Check if there is template information and format it as desired
-        template_signode = None
-        if file_data.compounddef.templateparamlist:
-            context = new_context.create_child_context(file_data.compounddef.templateparamlist)
-            renderer = self.renderer_factory.create_renderer(context)
-            template_nodes = [self.node_factory.Text("template <")]
-            template_nodes.extend(renderer.render())
-            template_nodes.append(self.node_factory.Text(">"))
-            template_signode = self.node_factory.desc_signature()
-            template_signode.extend(template_nodes)
+        template_signode = self.create_template_node(file_data.compounddef)
 
         if node:
             signode, contentnode = node.children


### PR DESCRIPTION
The proposed PR makes `doxygenfunction` directive work with both Sphinx 1.2 and Sphinx 1.3 by delegating most of the rendering to the relevant domain directives instead of using internal APIs of the `cpp` domain. This fixes issue #144 for top-level functions.

Other changes:
* Template handling code moved to a separate function `create_template_node` and reused between functions and classes.
* The `no-link` option is translated to the standard `noindex` option.

To complete Sphinx 1.3 support, we need to handle nested classes and functions in as similar fashion. To keep changes manageable, I'm thinking of submitting the rest as a different PR.