### PR TITLE
Rendering of inner constructs with domain directives and improved Sphinx 1.3 support

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -59,27 +59,6 @@ class BaseDirective(rst.Directive):
         self.target_handler_factory = target_handler_factory
         self.parser_factory = parser_factory
 
-    @staticmethod
-    def get_filename(node):
-        """Returns the name of a file where the declaration represented by node is located."""
-        try:
-            return node.location.file
-        except AttributeError:
-            return None
-
-    def get_domain(self, node_stack, project_info):
-        """Returns the domain for the declaration represented by node_stack."""
-        node = node_stack[0]
-        # An enumvalue node doesn't have location, so use its parent node for detecting the domain instead.
-        if node.node_type == "enumvalue":
-            node = node_stack[1]
-        filename = BaseDirective.get_filename(node)
-        if not filename and node.node_type == "compound":
-            compound_parser = self.parser_factory.create_compound_parser(project_info)
-            file_data = compound_parser.parse(node.refid)
-            filename = BaseDirective.get_filename(file_data.compounddef)
-        return project_info.domain_for_file(filename)
-
     def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
         "Standard render process used by subclasses"
 
@@ -104,17 +83,6 @@ class BaseDirective(rst.Directive):
         except FileIOError as e:
             return format_parser_error("doxygenclass", e.error, e.filename, self.state, self.lineno)
 
-        # Defer to domains specific directive.
-        domain = self.get_domain(node_stack, project_info)
-        # TODO: replace domain_directive_factories dictionary with an object
-        domain_directive = renderer_factory.domain_directive_factories[domain].create(self.directive_args)
-        # Translate Breathe's no-link option into the standard noindex option.
-        if 'no-link' in options:
-            domain_directive.options['noindex'] = True
-        result = domain_directive.run()
-
-        context = RenderContext(node_stack, mask_factory)
+        context = RenderContext(node_stack, mask_factory, self.directive_args)
         object_renderer = renderer_factory.create_renderer(context)
-        object_renderer.render(result[1])
-
-        return result
+        return object_renderer.render()

--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -47,8 +47,7 @@ def create_warning(project_info, state, lineno, **kwargs):
 class BaseDirective(rst.Directive):
 
     def __init__(self, root_data_object, renderer_factory_creator_constructor, finder_factory,
-                 project_info_factory, filter_factory, target_handler_factory, domain_directive_factories,
-                 parser_factory, *args):
+                 project_info_factory, filter_factory, target_handler_factory, parser_factory, *args):
         rst.Directive.__init__(self, *args)
         self.directive_args = list(args)  # Convert tuple to list to allow modification.
 
@@ -58,7 +57,6 @@ class BaseDirective(rst.Directive):
         self.project_info_factory = project_info_factory
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
-        self.domain_directive_factories = domain_directive_factories
         self.parser_factory = parser_factory
 
     @staticmethod
@@ -82,7 +80,7 @@ class BaseDirective(rst.Directive):
             filename = BaseDirective.get_filename(file_data.compounddef)
         return project_info.domain_for_file(filename)
 
-    def do_render(self, node_stack, project_info, options, filter_, target_handler, mask_factory, node=None):
+    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
         "Standard render process used by subclasses"
 
         renderer_factory_creator = self.renderer_factory_creator_constructor.create_factory_creator(
@@ -106,20 +104,17 @@ class BaseDirective(rst.Directive):
         except FileIOError as e:
             return format_parser_error("doxygenclass", e.error, e.filename, self.state, self.lineno)
 
-        context = RenderContext(node_stack, mask_factory)
-        object_renderer = renderer_factory.create_renderer(context)
-        node_list = object_renderer.render(node)
-
-        return node_list
-
-    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
         # Defer to domains specific directive.
         domain = self.get_domain(node_stack, project_info)
         # TODO: replace domain_directive_factories dictionary with an object
-        domain_directive = self.domain_directive_factories[domain].create(self.directive_args)
+        domain_directive = renderer_factory.domain_directive_factories[domain].create(self.directive_args)
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in options:
             domain_directive.options['noindex'] = True
         result = domain_directive.run()
-        self.do_render(node_stack, project_info, options, filter_, target_handler, mask_factory, result[1])
+
+        context = RenderContext(node_stack, mask_factory)
+        object_renderer = renderer_factory.create_renderer(context)
+        object_renderer.render(result[1])
+
         return result

--- a/breathe/directive/file.py
+++ b/breathe/directive/file.py
@@ -59,7 +59,7 @@ class BaseFileDirective(BaseDirective):
                 )
 
             mask_factory = NullMaskFactory()
-            context = RenderContext(node_stack, mask_factory)
+            context = RenderContext(node_stack, mask_factory, self.directive_args)
             object_renderer = renderer_factory.create_renderer(context)
             node_list.extend(object_renderer.render())
 

--- a/breathe/directive/index.py
+++ b/breathe/directive/index.py
@@ -50,7 +50,7 @@ class BaseIndexDirective(BaseDirective):
             )
 
         mask_factory = NullMaskFactory()
-        context = RenderContext([data_object, self.root_data_object], mask_factory)
+        context = RenderContext([data_object, self.root_data_object], mask_factory, self.directive_args)
         object_renderer = renderer_factory.create_renderer(context)
 
         try:

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -851,8 +851,9 @@ class CPPDomainDirectiveFactory:
         'doxygenclass': (cpp.CPPClassObject, 'class'),
         'doxygenstruct': (cpp.CPPClassObject, 'class'),
         'doxygenfunction': (cpp.CPPFunctionObject, 'function'),
-        'doxygentypedef': (cpp.CPPTypeObject, 'type'),
         'doxygenenum': (cpp.CPPTypeObject, 'type'),
+        'doxygentypedef': (cpp.CPPTypeObject, 'type'),
+        'doxygenunion': (cpp.CPPTypeObject, 'type'),
         # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for enum values and
         # CPPMemberObject requires a type.
         'doxygenenumvalue': (cpp.CPPClassObject, 'member')

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -853,7 +853,7 @@ class FileStateCache(object):
             del self.app.env.breathe_file_state[filename]
 
 
-class DomainDirectiveFactory:
+class DomainDirectiveFactory(object):
     # A mapping from node kinds to cpp domain classes and directive names.
     cpp_classes = {
         'class': (cpp.CPPClassObject, 'class'),

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -261,8 +261,7 @@ class DoxygenFunctionDirective(BaseDirective):
                 )
             filter_ = self.filter_factory.create_outline_filter(text_options)
             mask_factory = MaskFactory({'param': NoParameterNamesMask})
-            nodes = self.do_render(entry, project_info, text_options, filter_, target_handler,
-                                   mask_factory)
+            nodes = self.render(entry, project_info, text_options, filter_, target_handler, mask_factory)
 
             # Render the nodes to text
             signature = self.text_renderer.render(nodes, self.state.document)
@@ -510,7 +509,7 @@ class DoxygenBaseItemDirective(BaseDirective):
 
         node_stack = matches[0]
         mask_factory = NullMaskFactory()
-        return self.do_render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
+        return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
 
 
 class DoxygenVariableDirective(DoxygenBaseItemDirective):
@@ -604,8 +603,7 @@ class DoxygenDirectiveFactory(object):
 
     def __init__(self, node_factory, text_renderer, root_data_object,
                  renderer_factory_creator_constructor, finder_factory,
-                 project_info_factory, filter_factory, target_handler_factory,
-                 domain_directive_factories, parser_factory):
+                 project_info_factory, filter_factory, target_handler_factory, parser_factory):
 
         self.node_factory = node_factory
         self.text_renderer = text_renderer
@@ -615,7 +613,6 @@ class DoxygenDirectiveFactory(object):
         self.project_info_factory = project_info_factory
         self.filter_factory = filter_factory
         self.target_handler_factory = target_handler_factory
-        self.domain_directive_factories = domain_directive_factories
         self.parser_factory = parser_factory
 
     # TODO: This methods should be scrapped as they are only called in one place. We should just
@@ -636,7 +633,6 @@ class DoxygenDirectiveFactory(object):
             self.project_info_factory,
             self.filter_factory,
             self.target_handler_factory,
-            self.domain_directive_factories,
             self.parser_factory
             )
 
@@ -689,7 +685,6 @@ class DoxygenDirectiveFactory(object):
             self.project_info_factory,
             self.filter_factory,
             self.target_handler_factory,
-            self.domain_directive_factories,
             self.parser_factory
             )
 
@@ -860,7 +855,7 @@ class CPPDomainDirectiveFactory:
 
     @staticmethod
     def create(args):
-        cls, name = CPPDomainDirectiveFactory.classes.get(args[0], cpp.CPPObject)
+        cls, name = CPPDomainDirectiveFactory.classes.get(args[0], (cpp.CPPMemberObject, 'member'))
         # Replace the directive name because domain directives don't know how to handle
         # Breathe's "doxygen" directives.
         args[0] = name
@@ -901,6 +896,7 @@ def setup(app):
     renderer_factory_creator_constructor = DoxygenToRstRendererFactoryCreatorConstructor(
         node_factory,
         parser_factory,
+        {"c": CDomainDirectiveFactory, "cpp": CPPDomainDirectiveFactory},
         default_domain_handler,
         domain_handler_factory_creator,
         rst_content_creator
@@ -926,7 +922,6 @@ def setup(app):
         project_info_factory,
         filter_factory,
         target_handler_factory,
-        {"c": CDomainDirectiveFactory, "cpp": CPPDomainDirectiveFactory},
         parser_factory
         )
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -851,7 +851,10 @@ class CPPDomainDirectiveFactory:
         'doxygenclass': (cpp.CPPClassObject, 'class'),
         'doxygenstruct': (cpp.CPPClassObject, 'class'),
         'doxygenfunction': (cpp.CPPFunctionObject, 'function'),
-        'doxygentypedef': (cpp.CPPTypeObject, 'type')
+        'doxygentypedef': (cpp.CPPTypeObject, 'type'),
+        # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for enum values and
+        # CPPMemberObject requires a type.
+        'doxygenenumvalue': (cpp.CPPClassObject, 'member')
     }
 
     @staticmethod

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -520,6 +520,16 @@ class DoxygenVariableDirective(DoxygenBaseItemDirective):
 
     kind = "variable"
 
+    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
+        # Remove 'extern' keyword as Sphinx doesn't support it.
+        definition = node_stack[0].definition
+        extern = 'extern '
+        if definition.startswith(extern):
+            definition = definition[len(extern):]
+        self.directive_args[1] = [definition]
+        return DoxygenBaseItemDirective.render(self, node_stack, project_info, options, filter_,
+                                               target_handler, mask_factory)
+
 
 class DoxygenDefineDirective(DoxygenBaseItemDirective):
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -436,7 +436,7 @@ class DoxygenContentBlockDirective(BaseDirective):
                 )
 
             mask_factory = NullMaskFactory()
-            context = RenderContext(node_stack, mask_factory)
+            context = RenderContext(node_stack, mask_factory, self.directive_args)
             object_renderer = renderer_factory.create_renderer(context)
             node_list.extend(object_renderer.render())
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -852,6 +852,7 @@ class CPPDomainDirectiveFactory:
         'doxygenstruct': (cpp.CPPClassObject, 'class'),
         'doxygenfunction': (cpp.CPPFunctionObject, 'function'),
         'doxygentypedef': (cpp.CPPTypeObject, 'type'),
+        'doxygenenum': (cpp.CPPTypeObject, 'type'),
         # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for enum values and
         # CPPMemberObject requires a type.
         'doxygenenumvalue': (cpp.CPPClassObject, 'member')

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -854,29 +854,28 @@ class FileStateCache(object):
 
 
 class DomainDirectiveFactory:
-    # A mapping from Breathe directive names to cpp domain classes and directive names.
+    # A mapping from node kinds to cpp domain classes and directive names.
     cpp_classes = {
-        'doxygenclass': (cpp.CPPClassObject, 'class'),
-        'doxygenstruct': (cpp.CPPClassObject, 'class'),
-        'doxygenfunction': (cpp.CPPFunctionObject, 'function'),
-        'doxygenenum': (cpp.CPPTypeObject, 'type'),
-        'doxygentypedef': (cpp.CPPTypeObject, 'type'),
-        'doxygenunion': (cpp.CPPTypeObject, 'type'),
+        'class': (cpp.CPPClassObject, 'class'),
+        'struct': (cpp.CPPClassObject, 'class'),
+        'function': (cpp.CPPFunctionObject, 'function'),
+        'enum': (cpp.CPPTypeObject, 'type'),
+        'typedef': (cpp.CPPTypeObject, 'type'),
+        'union': (cpp.CPPTypeObject, 'type'),
         # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for enum values and
         # CPPMemberObject requires a type.
-        'doxygenenumvalue': (cpp.CPPClassObject, 'member')
+        'enumvalue': (cpp.CPPClassObject, 'member')
     }
 
     @staticmethod
     def create(domain, args):
-        if domain == 'cpp':
-            cls, name = DomainDirectiveFactory.cpp_classes.get(args[0], (cpp.CPPMemberObject, 'member'))
-            # Replace the directive name because domain directives don't know how to handle
-            # Breathe's "doxygen" directives.
-            args = [name] + args[1:]
-            return cls(*args)
         if domain == 'c':
             return c.CObject(*args)
+        cls, name = DomainDirectiveFactory.cpp_classes.get(args[0], (cpp.CPPMemberObject, 'member'))
+        # Replace the directive name because domain directives don't know how to handle
+        # Breathe's "doxygen" directives.
+        args = [name] + args[1:]
+        return cls(*args)
 
 
 # Setup

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -850,7 +850,8 @@ class CPPDomainDirectiveFactory:
     classes = {
         'doxygenclass': (cpp.CPPClassObject, 'class'),
         'doxygenstruct': (cpp.CPPClassObject, 'class'),
-        'doxygenfunction': (cpp.CPPFunctionObject, 'function')
+        'doxygenfunction': (cpp.CPPFunctionObject, 'function'),
+        'doxygentypedef': (cpp.CPPTypeObject, 'type')
     }
 
     @staticmethod

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -273,10 +273,12 @@ class DoxygenFunctionDirective(BaseDirective):
         node = node_stack[0]
         params = []
         for param in node.param:
+            param = mask_factory.mask(param)
             param_type = param.type_.content_[0].value
             if not isinstance(param_type, unicode):
                 param_type = param_type.valueOf_
-            params.append(param_type + ' ' + (param.defname if param.defname else param.declname))
+            param_name = param.defname if param.defname else param.declname
+            params.append(param_type if not param_name else param_type + ' ' + param_name)
         signature = '{0}({1})'.format(node.definition, ', '.join(params))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
         virtual = 'virtual '

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -862,6 +862,7 @@ class DomainDirectiveFactory:
         'enum': (cpp.CPPTypeObject, 'type'),
         'typedef': (cpp.CPPTypeObject, 'type'),
         'union': (cpp.CPPTypeObject, 'type'),
+        'namespace': (cpp.CPPTypeObject, 'type'),
         # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for enum values and
         # CPPMemberObject requires a type.
         'enumvalue': (cpp.CPPClassObject, 'member')

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -31,9 +31,13 @@ class AutoProjectInfo(object):
         self._reference = reference
         self._source_dir = source_dir
         self._config_dir = config_dir
-        self._domain_by_extension = domain_by_extension
+        self._domain_by_extension = dict(domain_by_extension)
         self._domain_by_file_pattern = domain_by_file_pattern
         self._match = match
+
+        # Add default mapping from extension to domain  which can be overridden by the user.
+        if 'h' not in self._domain_by_extension:
+            self._domain_by_extension['h'] = 'c'
 
     def name(self):
         return self._name

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -31,13 +31,10 @@ class AutoProjectInfo(object):
         self._reference = reference
         self._source_dir = source_dir
         self._config_dir = config_dir
-        self._domain_by_extension = dict(domain_by_extension)
+        self._domain_by_extension = domain_by_extension
         self._domain_by_file_pattern = domain_by_file_pattern
         self._match = match
 
-        # Add default mapping from extension to domain  which can be overridden by the user.
-        if 'h' not in self._domain_by_extension:
-            self._domain_by_extension['h'] = 'c'
 
     def name(self):
         return self._name

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -73,7 +73,8 @@ class DoxygenToRstRendererFactory(object):
             domain_handler,
             rst_content_creator,
             filter_,
-            target_handler
+            target_handler,
+            domain_directive_factories
             ):
 
         self.node_type = node_type
@@ -89,6 +90,7 @@ class DoxygenToRstRendererFactory(object):
         self.rst_content_creator = rst_content_creator
         self.filter_ = filter_
         self.target_handler = target_handler
+        self.domain_directive_factories = domain_directive_factories
 
     def create_renderer(
             self,
@@ -128,7 +130,8 @@ class DoxygenToRstRendererFactory(object):
                 self.state,
                 self.document,
                 self.domain_handler,
-                self.target_handler
+                self.target_handler,
+                self.domain_directive_factories
                 ]
 
         if node_type == "docmarkup":
@@ -229,6 +232,7 @@ class DoxygenToRstRendererFactoryCreator(object):
             self,
             node_factory,
             parser_factory,
+            domain_directive_factories,
             default_domain_handler,
             rst_content_creator,
             domain_handler_factory,
@@ -237,6 +241,7 @@ class DoxygenToRstRendererFactoryCreator(object):
 
         self.node_factory = node_factory
         self.parser_factory = parser_factory
+        self.domain_directive_factories = domain_directive_factories
         self.default_domain_handler = default_domain_handler
         self.rst_content_creator = rst_content_creator
         self.domain_handler_factory = domain_handler_factory
@@ -322,7 +327,8 @@ class DoxygenToRstRendererFactoryCreator(object):
                 domain_handler,
                 self.rst_content_creator,
                 filter_,
-                target_handler
+                target_handler,
+                self.domain_directive_factories
                 )
 
     def create_child_factory( self, project_info, data_object, parent_renderer_factory ):
@@ -370,7 +376,8 @@ class DoxygenToRstRendererFactoryCreator(object):
                     domain_handler,
                     self.rst_content_creator,
                     parent_renderer_factory.filter_,
-                    parent_renderer_factory.target_handler
+                    parent_renderer_factory.target_handler,
+                    parent_renderer_factory.domain_directive_factories
                     )
 
 
@@ -391,6 +398,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
             self,
             node_factory,
             parser_factory,
+            domain_directive_factories,
             default_domain_handler,
             domain_handler_factory_creator,
             rst_content_creator
@@ -398,6 +406,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
 
         self.node_factory = node_factory
         self.parser_factory = parser_factory
+        self.domain_directive_factories = domain_directive_factories
         self.default_domain_handler = default_domain_handler
         self.domain_handler_factory_creator = domain_handler_factory_creator
         self.rst_content_creator = rst_content_creator
@@ -415,6 +424,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
         return DoxygenToRstRendererFactoryCreator(
                 self.node_factory,
                 self.parser_factory,
+                self.domain_directive_factories,
                 self.default_domain_handler,
                 self.rst_content_creator,
                 domain_handler_factory,

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -166,6 +166,10 @@ class DoxygenToRstRendererFactory(object):
 
         if node_type == "compound":
 
+            kind = data_object.kind
+            if kind == "file" or kind == "dir":
+                return Renderer(indexrenderer.FileRenderer, *common_args)
+
             class_ = indexrenderer.CompoundTypeSubRenderer
 
             # For compound node types Renderer is CreateCompoundTypeSubRenderer

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -167,7 +167,7 @@ class DoxygenToRstRendererFactory(object):
         if node_type == "compound":
 
             kind = data_object.kind
-            if kind in ["file", "dir", "page", "example"]:
+            if kind in ["file", "dir", "page", "example", "group"]:
                 return Renderer(indexrenderer.FileRenderer, *common_args)
 
             class_ = indexrenderer.CompoundTypeSubRenderer

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -167,7 +167,7 @@ class DoxygenToRstRendererFactory(object):
         if node_type == "compound":
 
             kind = data_object.kind
-            if kind == "file" or kind == "dir":
+            if kind in ["file", "dir", "page", "example"]:
                 return Renderer(indexrenderer.FileRenderer, *common_args)
 
             class_ = indexrenderer.CompoundTypeSubRenderer

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -74,7 +74,7 @@ class DoxygenToRstRendererFactory(object):
             rst_content_creator,
             filter_,
             target_handler,
-            domain_directive_factories
+            domain_directive_factory
             ):
 
         self.node_type = node_type
@@ -90,7 +90,7 @@ class DoxygenToRstRendererFactory(object):
         self.rst_content_creator = rst_content_creator
         self.filter_ = filter_
         self.target_handler = target_handler
-        self.domain_directive_factories = domain_directive_factories
+        self.domain_directive_factory = domain_directive_factory
 
     def create_renderer(
             self,
@@ -131,7 +131,7 @@ class DoxygenToRstRendererFactory(object):
                 self.document,
                 self.domain_handler,
                 self.target_handler,
-                self.domain_directive_factories
+                self.domain_directive_factory
                 ]
 
         if node_type == "docmarkup":
@@ -232,7 +232,7 @@ class DoxygenToRstRendererFactoryCreator(object):
             self,
             node_factory,
             parser_factory,
-            domain_directive_factories,
+            domain_directive_factory,
             default_domain_handler,
             rst_content_creator,
             domain_handler_factory,
@@ -241,7 +241,7 @@ class DoxygenToRstRendererFactoryCreator(object):
 
         self.node_factory = node_factory
         self.parser_factory = parser_factory
-        self.domain_directive_factories = domain_directive_factories
+        self.domain_directive_factory = domain_directive_factory
         self.default_domain_handler = default_domain_handler
         self.rst_content_creator = rst_content_creator
         self.domain_handler_factory = domain_handler_factory
@@ -328,7 +328,7 @@ class DoxygenToRstRendererFactoryCreator(object):
                 self.rst_content_creator,
                 filter_,
                 target_handler,
-                self.domain_directive_factories
+                self.domain_directive_factory
                 )
 
     def create_child_factory( self, project_info, data_object, parent_renderer_factory ):
@@ -377,7 +377,7 @@ class DoxygenToRstRendererFactoryCreator(object):
                     self.rst_content_creator,
                     parent_renderer_factory.filter_,
                     parent_renderer_factory.target_handler,
-                    parent_renderer_factory.domain_directive_factories
+                    parent_renderer_factory.domain_directive_factory
                     )
 
 
@@ -398,7 +398,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
             self,
             node_factory,
             parser_factory,
-            domain_directive_factories,
+            domain_directive_factory,
             default_domain_handler,
             domain_handler_factory_creator,
             rst_content_creator
@@ -406,7 +406,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
 
         self.node_factory = node_factory
         self.parser_factory = parser_factory
-        self.domain_directive_factories = domain_directive_factories
+        self.domain_directive_factory = domain_directive_factory
         self.default_domain_handler = default_domain_handler
         self.domain_handler_factory_creator = domain_handler_factory_creator
         self.rst_content_creator = rst_content_creator
@@ -424,7 +424,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
         return DoxygenToRstRendererFactoryCreator(
                 self.node_factory,
                 self.parser_factory,
-                self.domain_directive_factories,
+                self.domain_directive_factory,
                 self.default_domain_handler,
                 self.rst_content_creator,
                 domain_handler_factory,

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -9,7 +9,8 @@ class Renderer(object):
             state,
             document,
             domain_handler,
-            target_handler
+            target_handler,
+            domain_directive_factories
             ):
 
         self.project_info = project_info
@@ -21,6 +22,7 @@ class Renderer(object):
         self.document = document
         self.domain_handler = domain_handler
         self.target_handler = target_handler
+        self.domain_directive_factories = domain_directive_factories
 
     def create_template_node(self, decl):
         """Creates a node for the ``template <...>`` part of the declaration."""

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -10,7 +10,7 @@ class Renderer(object):
             document,
             domain_handler,
             target_handler,
-            domain_directive_factories,
+            domain_directive_factory,
             ):
 
         self.project_info = project_info
@@ -22,7 +22,7 @@ class Renderer(object):
         self.document = document
         self.domain_handler = domain_handler
         self.target_handler = target_handler
-        self.domain_directive_factories = domain_directive_factories
+        self.domain_directive_factory = domain_directive_factory
 
         if self.context.domain == '':
             self.context.domain = self.get_domain()

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -10,7 +10,7 @@ class Renderer(object):
             document,
             domain_handler,
             target_handler,
-            domain_directive_factories
+            domain_directive_factories,
             ):
 
         self.project_info = project_info
@@ -40,12 +40,13 @@ class Renderer(object):
 
 class RenderContext(object):
 
-    def __init__(self, node_stack, mask_factory):
+    def __init__(self, node_stack, mask_factory, directive_args):
         self.node_stack = node_stack
         self.mask_factory = mask_factory
+        self.directive_args = directive_args
 
     def create_child_context(self, data_object):
 
         node_stack = self.node_stack[:]
         node_stack.insert(0, self.mask_factory.mask(data_object))
-        return RenderContext(node_stack, self.mask_factory)
+        return RenderContext(node_stack, self.mask_factory, self.directive_args)

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -40,7 +40,7 @@ class Renderer(object):
         node_stack = self.context.node_stack
         node = node_stack[0]
         # An enumvalue node doesn't have location, so use its parent node for detecting the domain instead.
-        if node.node_type == "enumvalue":
+        if type(node) == unicode or node.node_type == "enumvalue":
             node = node_stack[1]
         filename = get_filename(node)
         if not filename and node.node_type == "compound":

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -40,13 +40,14 @@ class Renderer(object):
 
 class RenderContext(object):
 
-    def __init__(self, node_stack, mask_factory, directive_args):
+    def __init__(self, node_stack, mask_factory, directive_args, domain=None):
         self.node_stack = node_stack
         self.mask_factory = mask_factory
         self.directive_args = directive_args
+        self.domain = domain
 
     def create_child_context(self, data_object):
 
         node_stack = self.node_stack[:]
         node_stack.insert(0, self.mask_factory.mask(data_object))
-        return RenderContext(node_stack, self.mask_factory, self.directive_args)
+        return RenderContext(node_stack, self.mask_factory, self.directive_args, self.domain)

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -218,8 +218,8 @@ class MemberDefTypeSubRenderer(Renderer):
 
         return self.data_object.kind
 
-    def add_qualifiers(self, signode):
-        """Adds qualifiers to the signature node if necessary."""
+    def update_signature(self, signode):
+        """Update the signature node if necessary, e.g. add qualifiers."""
         pass
 
     def render(self, node=None):
@@ -227,7 +227,7 @@ class MemberDefTypeSubRenderer(Renderer):
         doxygen_target = self.create_doxygen_target()
         if node:
             signode, contentnode = node.children
-            self.add_qualifiers(signode)
+            self.update_signature(signode)
             signode.insert(0, doxygen_target)
         else:
             # Build targets for linking
@@ -256,7 +256,7 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
         return self.domain_handler.create_function_target(self.data_object)
 
-    def add_qualifiers(self, signode):
+    def update_signature(self, signode):
 
         # Note whether a member function is virtual
         if self.data_object.virt != 'non-virtual':
@@ -304,7 +304,7 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
             paramlist.append(param)
         nodes.append(paramlist)
 
-        self.add_qualifiers(nodes)
+        self.update_signature(nodes)
         return nodes
 
     def render(self, node=None):
@@ -423,6 +423,11 @@ class EnumvalueTypeSubRenderer(MemberDefTypeSubRenderer):
     def objtype(self):
 
         return 'enumvalue'
+
+    def update_signature(self, signode):
+        # Remove "class" from the signature. This is needed because Sphinx cpp domain doesn't have an enum value
+        # directive and we use a class directive instead.
+        signode.children.pop(0)
 
 
 class DescriptionTypeSubRenderer(Renderer):

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -368,6 +368,11 @@ class EnumMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
         return description_nodes
 
+    def update_signature(self, signode):
+        # Replace "type" with "enum" in the signature. This is needed because Sphinx cpp domain doesn't have an enum
+        # directive and we use a type directive instead.
+        signode.children[0][0] = self.node_factory.Text("enum ")
+
 
 class TypedefMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -39,7 +39,7 @@ class CompoundRenderer(Renderer):
         name, kind = self.get_node_info(file_data)
         domain_directive = self.renderer_factory.domain_directive_factory.create(
             self.context.domain, [kind] + self.context.directive_args[1:])
-        domain_directive.arguments = [kind + ' ' + name]
+        domain_directive.arguments = [name]
 
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
@@ -50,7 +50,7 @@ class CompoundRenderer(Renderer):
         signode, contentnode = node.children
         # The cpp domain in Sphinx doesn't support structs at the moment, so change the text from "class "
         # to the correct kind which can be "class " or "struct ".
-        signode[0].children[0] = self.node_factory.Text(kind + " ")
+        signode[0] = self.node_factory.desc_annotation(kind + ' ', kind + ' ')
 
         # Check if there is template information and format it as desired
         template_signode = self.create_template_node(file_data.compounddef)

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -38,7 +38,7 @@ class CompoundRenderer(Renderer):
         # Defer to domains specific directive.
         name, kind = self.get_node_info(file_data)
         domain_directive = self.renderer_factory.domain_directive_factory.create(
-            self.context.domain, self.context.directive_args)
+            self.context.domain, [kind] + self.context.directive_args[1:])
         domain_directive.arguments = [kind + ' ' + name]
 
         # Translate Breathe's no-link option into the standard noindex option.

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -61,6 +61,8 @@ class CompoundRenderer(Renderer):
         # Read in the corresponding xml file and process
         file_data = self.compound_parser.parse(self.data_object.refid)
 
+        if not self.context.domain:
+            self.context.domain = self.get_domain()
         parent_context = self.context.create_child_context(file_data)
 
         name, kind = self.get_node_info(file_data)
@@ -79,9 +81,10 @@ class CompoundRenderer(Renderer):
         template_signode = self.create_template_node(file_data.compounddef)
 
         # Defer to domains specific directive.
-        domain = self.get_domain()
         # TODO: replace domain_directive_factories dictionary with an object
-        domain_directive = self.renderer_factory.domain_directive_factories[domain].create(self.context.directive_args)
+        domain_directive = self.renderer_factory.domain_directive_factories[self.context.domain].create(
+            self.context.directive_args)
+        domain_directive.arguments[0] = name
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
             domain_directive.options['noindex'] = True

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -38,10 +38,15 @@ class CompoundRenderer(Renderer):
 
         names = []
         node_stack = self.context.node_stack
-        if node_stack[0].node_type == 'enumvalue':
-            names.append(node_stack[0].name)
+        node = node_stack[0]
+        if node.node_type == 'enumvalue':
+            names.append(node.name)
             # Skip the name of the containing enum because it is not a part of the fully qualified name.
             node_stack = node_stack[2:]
+
+        # If the node is a namespace, use its name because namespaces are skipped in the main loop.
+        if node.node_type == 'compound' and node.kind == 'namespace':
+            names.append(node.name)
 
         for node in node_stack:
             if node.node_type == 'ref':

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -84,7 +84,7 @@ class CompoundRenderer(Renderer):
         # TODO: replace domain_directive_factories dictionary with an object
         domain_directive = self.renderer_factory.domain_directive_factories[self.context.domain].create(
             self.context.directive_args)
-        domain_directive.arguments[0] = name
+        domain_directive.arguments[0] = kind + ' ' + name
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
             domain_directive.options['noindex'] = True

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -84,7 +84,7 @@ class CompoundRenderer(Renderer):
         # TODO: replace domain_directive_factories dictionary with an object
         domain_directive = self.renderer_factory.domain_directive_factories[self.context.domain].create(
             self.context.directive_args)
-        domain_directive.arguments[0] = kind + ' ' + name
+        domain_directive.arguments = [kind + ' ' + name]
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
             domain_directive.options['noindex'] = True

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -34,12 +34,42 @@ class CompoundRenderer(Renderer):
         refid = "%s%s" % (self.project_info.name(), self.data_object.refid)
         return self.target_handler.create_target(refid)
 
+    def get_fully_qualified_name(self):
+
+        names = []
+        node_stack = self.context.node_stack
+        if node_stack[0].node_type == 'enumvalue':
+            names.append(node_stack[0].name)
+            # Skip the name of the containing enum because it is not a part of the fully qualified name.
+            node_stack = node_stack[2:]
+
+        for node in node_stack:
+            if node.node_type == 'ref':
+                return node.valueOf_
+            if (node.node_type == 'compound' and node.kind not in ['file', 'namespace']) or \
+                node.node_type == 'memberdef':
+                # We skip the 'file' entries because the file name doesn't form part of the
+                # qualified name for the identifier. We skip the 'namespace' entries because if we
+                # find an object through the namespace 'compound' entry in the index.xml then we'll
+                # also have the 'compounddef' entry in our node stack and we'll get it from that. We
+                # need the 'compounddef' entry because if we find the object through the 'file'
+                # entry in the index.xml file then we need to get the namespace name from somewhere
+                names.insert(0, node.name)
+            if (node.node_type == 'compounddef' and node.kind == 'namespace'):
+                # Nested namespaces include there parent namespace in there compoundname. ie,
+                # compoundname is 'foo::bar' instead of just 'bar' for namespace 'bar' nested in
+                # namespace 'foo'. But our node_stack includes 'foo' so we only want 'bar' at
+                # this point.
+                names.insert(0, node.compoundname.split('::')[-1])
+
+        return '::'.join(names)
+
     def render_signature(self, file_data, doxygen_target):
         # Defer to domains specific directive.
         name, kind = self.get_node_info(file_data)
         domain_directive = self.renderer_factory.domain_directive_factory.create(
             self.context.domain, [kind] + self.context.directive_args[1:])
-        domain_directive.arguments = [name]
+        domain_directive.arguments = [self.get_fully_qualified_name()]
 
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
@@ -51,6 +81,11 @@ class CompoundRenderer(Renderer):
         # The cpp domain in Sphinx doesn't support structs at the moment, so change the text from "class "
         # to the correct kind which can be "class " or "struct ".
         signode[0] = self.node_factory.desc_annotation(kind + ' ', kind + ' ')
+
+        # Filter out outer class names if we are rendering an inner class as a part of its outer class content.
+        names = self.context.directive_args[1]
+        if len(names) > 0 and names[0] != name:
+            signode.children = [n for n in signode.children if not n.tagname == 'desc_addname']
 
         # Check if there is template information and format it as desired
         template_signode = self.create_template_node(file_data.compounddef)

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -20,10 +20,9 @@ class CompoundRenderer(Renderer):
     """Base class for CompoundTypeSubRenderer and RefTypeSubRenderer."""
 
     def __init__(self, compound_parser, render_empty_node, *args):
-        Renderer.__init__(self, *args)
-
         self.compound_parser = compound_parser
         self.render_empty_node = render_empty_node
+        Renderer.__init__(self, *args)
 
     def create_doxygen_target(self):
         """Can be overridden to create a target node which uses the doxygen refid information
@@ -35,34 +34,11 @@ class CompoundRenderer(Renderer):
         refid = "%s%s" % (self.project_info.name(), self.data_object.refid)
         return self.target_handler.create_target(refid)
 
-    def get_domain(self):
-        """Returns the domain for the current node."""
-
-        def get_filename(node):
-            """Returns the name of a file where the declaration represented by node is located."""
-            try:
-                return node.location.file
-            except AttributeError:
-                return None
-
-        node_stack = self.context.node_stack
-        node = node_stack[0]
-        # An enumvalue node doesn't have location, so use its parent node for detecting the domain instead.
-        if node.node_type == "enumvalue":
-            node = node_stack[1]
-        filename = get_filename(node)
-        if not filename and node.node_type == "compound":
-            file_data = self.compound_parser.parse(node.refid)
-            filename = get_filename(file_data.compounddef)
-        return self.project_info.domain_for_file(filename)
-
     def render(self, node=None):
 
         # Read in the corresponding xml file and process
         file_data = self.compound_parser.parse(self.data_object.refid)
 
-        if not self.context.domain:
-            self.context.domain = self.get_domain()
         parent_context = self.context.create_child_context(file_data)
 
         name, kind = self.get_node_info(file_data)


### PR DESCRIPTION
The proposed PR implements rendering of inner language constructs, such as classes, with domain directives. To achieve this, the domain directive factory (which is now an object, not a dictionary) is propagated to renderers and used to create domain directives whenever we need to render something. Constructs such as files that are not part of the language are rendered with a new class, `FileRenderer`.

Enums, typedefs, unions and namespaces are rendered using `:cpp:type` directive as Sphinx doesn't have designated directives. This is probably OK for the first three as they are actually types, but not great for namespaces. This might be something we'd like to contribute to Sphinx in the future.

Rendering of functions is temporary back to the old state (without using Sphinx directives) as adding function support would make the PR even bigger. I plan to add this in the next PR which will complete integration with Sphinx and make all Breathe features work with both Sphinx 1.2 and 1.3.
