### PR TITLE
Rendering of functions with domain directives and Sphinx 1.3 support

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -268,25 +268,6 @@ class DoxygenFunctionDirective(BaseDirective):
 
         return node_stack
 
-    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
-        # Get full function signature for the domain directive.
-        node = node_stack[0]
-        params = []
-        for param in node.param:
-            param = mask_factory.mask(param)
-            param_type = param.type_.content_[0].value
-            if not isinstance(param_type, unicode):
-                param_type = param_type.valueOf_
-            param_name = param.defname if param.defname else param.declname
-            params.append(param_type if not param_name else param_type + ' ' + param_name)
-        signature = '{0}({1})'.format(node.definition, ', '.join(params))
-        # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
-        virtual = 'virtual '
-        if signature.startswith(virtual):
-            signature = signature[len(virtual):]
-        self.directive_args[1] = [signature]
-        return BaseDirective.render(self, node_stack, project_info, options, filter_, target_handler, mask_factory)
-
 
 class DoxygenClassLikeDirective(BaseDirective):
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -840,6 +840,7 @@ class DomainDirectiveFactory(object):
         'class': (cpp.CPPClassObject, 'class'),
         'struct': (cpp.CPPClassObject, 'class'),
         'function': (cpp.CPPFunctionObject, 'function'),
+        'slot': (cpp.CPPFunctionObject, 'function'),
         'enum': (cpp.CPPTypeObject, 'type'),
         'typedef': (cpp.CPPTypeObject, 'type'),
         'union': (cpp.CPPTypeObject, 'type'),

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -61,6 +61,15 @@ class Renderer(object):
         signode.extend(nodes)
         return signode
 
+    def run_domain_directive(self, kind):
+        domain_directive = self.renderer_factory.domain_directive_factory.create(
+            self.context.domain, [kind] + self.context.directive_args[1:])
+
+        # Translate Breathe's no-link option into the standard noindex option.
+        if 'no-link' in self.context.directive_args[2]:
+            domain_directive.options['noindex'] = True
+        return domain_directive.run()
+
 
 class RenderContext(object):
 

--- a/breathe/renderer/rst/doxygen/base.py
+++ b/breathe/renderer/rst/doxygen/base.py
@@ -68,19 +68,27 @@ class Renderer(object):
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
             domain_directive.options['noindex'] = True
-        return domain_directive.run()
+        nodes = domain_directive.run()
+
+        # Filter out outer class names if we are rendering a member as a part of a class content.
+        signode = nodes[1].children[0]
+        names = self.context.directive_args[1]
+        if len(names) > 0 and self.context.child:
+            signode.children = [n for n in signode.children if not n.tagname == 'desc_addname']
+        return nodes
 
 
 class RenderContext(object):
 
-    def __init__(self, node_stack, mask_factory, directive_args, domain=''):
+    def __init__(self, node_stack, mask_factory, directive_args, domain='', child=False):
         self.node_stack = node_stack
         self.mask_factory = mask_factory
         self.directive_args = directive_args
         self.domain = domain
+        self.child = child
 
     def create_child_context(self, data_object):
 
         node_stack = self.node_stack[:]
         node_stack.insert(0, self.mask_factory.mask(data_object))
-        return RenderContext(node_stack, self.mask_factory, self.directive_args, self.domain)
+        return RenderContext(node_stack, self.mask_factory, self.directive_args, self.domain, True)

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -311,6 +311,7 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         # Get full function signature for the domain directive.
         params = []
         for param in self.data_object.param:
+            param = self.context.mask_factory.mask(param)
             param_type = []
             for p in param.type_.content_:
                 value = p.value

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -318,7 +318,7 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
                     value = value.valueOf_
                 param_type.append(value)
             param_type = ' '.join(param_type)
-            param_name = param.defname if param.defname else param.declname
+            param_name = param.declname if param.declname else param.defname
             params.append(param_type if not param_name else param_type + ' ' + param_name)
         signature = '{0}({1})'.format(self.data_object.definition, ', '.join(params))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -311,9 +311,13 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         # Get full function signature for the domain directive.
         params = []
         for param in self.data_object.param:
-            param_type = param.type_.content_[0].value
-            if not isinstance(param_type, unicode):
-                param_type = param_type.valueOf_
+            param_type = []
+            for p in param.type_.content_:
+                value = p.value
+                if not isinstance(value, unicode):
+                    value = value.valueOf_
+                param_type.append(value)
+            param_type = ' '.join(param_type)
             param_name = param.defname if param.defname else param.declname
             params.append(param_type if not param_name else param_type + ' ' + param_name)
         signature = '{0}({1})'.format(self.data_object.definition, ', '.join(params))
@@ -672,7 +676,6 @@ class DocParamListTypeSubRenderer(Renderer):
         definition = self.node_factory.definition('', nodelist_list)
 
         return [self.node_factory.definition_list_item('', term, definition)]
-
 
 
 class DocParamListItemSubRenderer(Renderer):

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -72,17 +72,11 @@ class CompoundRenderer(Renderer):
     def render_signature(self, file_data, doxygen_target):
         # Defer to domains specific directive.
         name, kind = self.get_node_info(file_data)
-        domain_directive = self.renderer_factory.domain_directive_factory.create(
-            self.context.domain, [kind] + self.context.directive_args[1:])
-        domain_directive.arguments = [self.get_fully_qualified_name()]
-
-        # Translate Breathe's no-link option into the standard noindex option.
-        if 'no-link' in self.context.directive_args[2]:
-            domain_directive.options['noindex'] = True
-        nodes = domain_directive.run()
+        self.context.directive_args[1] = [self.get_fully_qualified_name()]
+        nodes = self.run_domain_directive(kind)
         node = nodes[1]
-
         signode, contentnode = node.children
+
         # The cpp domain in Sphinx doesn't support structs at the moment, so change the text from "class "
         # to the correct kind which can be "class " or "struct ".
         signode[0] = self.node_factory.desc_annotation(kind + ' ', kind + ' ')

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -81,11 +81,6 @@ class CompoundRenderer(Renderer):
         # to the correct kind which can be "class " or "struct ".
         signode[0] = self.node_factory.desc_annotation(kind + ' ', kind + ' ')
 
-        # Filter out outer class names if we are rendering an inner class as a part of its outer class content.
-        names = self.context.directive_args[1]
-        if len(names) > 0 and names[0] != name:
-            signode.children = [n for n in signode.children if not n.tagname == 'desc_addname']
-
         # Check if there is template information and format it as desired
         template_signode = self.create_template_node(file_data.compounddef)
         if template_signode:


### PR DESCRIPTION
The proposed PR implements rendering of functions with domain directives. With this change it is now possible to use Breathe with Sphinx 1.3 on nontrivial documentation without exceptions (#144). For example, I was able to build the documentation for [C++ Format](https://github.com/cppformat/cppformat) with only minor issues. Breathe's docs cannot be built with Sphinx 1.3 yet, but I think we are getting close.

One issue with the new implementation is that links to parameter types in signatures are no longer generated. I plan to address this in the next PR.