### PR TITLE
Fix rendering of Python objects and clean up

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -19,7 +19,7 @@ from .project import ProjectInfoFactory, ProjectError
 
 from docutils.parsers.rst.directives import unchanged_required, unchanged, flag
 from docutils.statemachine import ViewList
-from sphinx.domains import cpp, c
+from sphinx.domains import cpp, c, python
 from sphinx.writers.text import TextWriter
 from sphinx.builders.text import TextBuilder
 
@@ -850,11 +850,27 @@ class DomainDirectiveFactory(object):
         'enumvalue': (cpp.CPPClassObject, 'member')
     }
 
+    python_classes = {
+        'function': (python.PyModulelevel, 'function')
+    }
+
+    @staticmethod
+    def fix_python_signature(sig):
+        def_ = 'def '
+        if sig.startswith(def_):
+            sig = sig[len(def_):]
+        # Doxygen uses an invalid separator ('::') in Python signatures. Replace them with '.'.
+        return sig.replace('::', '.')
+
     @staticmethod
     def create(domain, args):
         if domain == 'c':
             return c.CObject(*args)
-        cls, name = DomainDirectiveFactory.cpp_classes.get(args[0], (cpp.CPPMemberObject, 'member'))
+        if domain == 'py':
+            cls, name = DomainDirectiveFactory.python_classes.get(args[0], (python.PyClasslike, 'class'))
+            args[1] = [DomainDirectiveFactory.fix_python_signature(n) for n in args[1]]
+        else:
+            cls, name = DomainDirectiveFactory.cpp_classes.get(args[0], (cpp.CPPMemberObject, 'member'))
         # Replace the directive name because domain directives don't know how to handle
         # Breathe's "doxygen" directives.
         args = [name] + args[1:]

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -1019,7 +1019,8 @@ def setup(app):
 
     app.add_config_value("breathe_projects", {}, True)
     app.add_config_value("breathe_default_project", "", True)
-    app.add_config_value("breathe_domain_by_extension", {}, True)
+    # Provide reasonable defaults for domain_by_extension mapping. Can be overridden by users.
+    app.add_config_value("breathe_domain_by_extension", {'py': 'py'}, True)
     app.add_config_value("breathe_domain_by_file_pattern", {}, True)
     app.add_config_value("breathe_projects_source", {}, True)
     app.add_config_value("breathe_build_directory", '', True)

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -172,12 +172,9 @@ class ProjectInfoFactory(object):
             build_dir
             ):
 
-        # Provide reasonable defaults for domain_by_extension mapping. Can be overridden by users.
-        default_domain_by_extension = {'py': 'py'}
-
         self.projects = projects
         self.default_project = default_project
-        self.domain_by_extension = dict(default_domain_by_extension.items() + domain_by_extension.items())
+        self.domain_by_extension = domain_by_extension
         self.domain_by_file_pattern = domain_by_file_pattern
         self.projects_source = projects_source
 

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -172,9 +172,12 @@ class ProjectInfoFactory(object):
             build_dir
             ):
 
+        # Provide reasonable defaults for domain_by_extension mapping. Can be overridden by users.
+        default_domain_by_extension = {'py': 'py'}
+
         self.projects = projects
         self.default_project = default_project
-        self.domain_by_extension = domain_by_extension
+        self.domain_by_extension = dict(default_domain_by_extension.items() + domain_by_extension.items())
         self.domain_by_file_pattern = domain_by_file_pattern
         self.projects_source = projects_source
 

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -222,29 +222,24 @@ class MemberDefTypeSubRenderer(Renderer):
         """Update the signature node if necessary, e.g. add qualifiers."""
         pass
 
-    def render(self, node=None):
+    def render(self):
 
         doxygen_target = self.create_doxygen_target()
-        if node:
-            signode, contentnode = node.children
-            self.update_signature(signode)
-            signode.insert(0, doxygen_target)
-        else:
-            # Build targets for linking
-            targets = []
-            targets.extend(self.create_domain_target())
-            targets.extend(doxygen_target)
+        # Build targets for linking
+        targets = []
+        targets.extend(self.create_domain_target())
+        targets.extend(doxygen_target)
 
-            signodes = self.build_signodes(targets)
+        signodes = self.build_signodes(targets)
 
-            # Build description nodes
-            contentnode = self.node_factory.desc_content()
+        # Build description nodes
+        contentnode = self.node_factory.desc_content()
 
-            node = self.node_factory.desc()
-            node.document = self.state.document
-            node['objtype'] = self.objtype()
-            node.extend(signodes)
-            node.append(contentnode)
+        node = self.node_factory.desc()
+        node.document = self.state.document
+        node['objtype'] = self.objtype()
+        node.extend(signodes)
+        node.append(contentnode)
 
         contentnode.extend(self.description())
         return [node]
@@ -307,7 +302,7 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         self.update_signature(nodes)
         return nodes
 
-    def render(self, node=None):
+    def render(self):
         # Get full function signature for the domain directive.
         params = []
         for param in self.data_object.param:

--- a/breathe/renderer/rst/doxygen/index.py
+++ b/breathe/renderer/rst/doxygen/index.py
@@ -88,7 +88,7 @@ class CompoundRenderer(Renderer):
         node.children[0].insert(0, doxygen_target)
         return nodes, contentnode
 
-    def render(self, node=None):
+    def render(self):
 
         # Read in the corresponding xml file and process
         file_data = self.compound_parser.parse(self.data_object.refid)

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -217,6 +217,7 @@ breathe_default_project = "tinyxml"
 
 breathe_domain_by_extension = {
         "h" : "cpp",
+        "py": "py",
         }
 
 breathe_domain_by_file_pattern = {


### PR DESCRIPTION
The proposed PR implements rendering of Python objects with domain directives and removes unused argument `node` from `render` methods.