### PR TITLE
Add multiple Sphinx version & flake8 coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 
 language: python
 
+env:
+  - SPHINX_VERSION=1.2.3 TRAVIS_CI=True
+  - SPHINX_VERSION=1.3.1 TRAVIS_CI=True
+
 python:
   - "2.6"
   - "2.7"
@@ -12,11 +16,8 @@ before_install:
   - sudo apt-get install -y doxygen texlive-latex-base texlive-latex-extra texlive-fonts-recommended
 
 install:
-  - pip install -r requirements/production.txt
+  - pip install Sphinx==$SPHINX_VERSION
   - pip install .
-
-env:
-  - TRAVIS_CI=True
 
 # Builds all examples & html documentation
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ install:
 # to run `which doxygen`
 script:
   - make DOXYGEN=doxygen DEBUG=""
-  - flake8
+  - flake8 breathe/*.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - sudo apt-get install -y doxygen texlive-latex-base texlive-latex-extra texlive-fonts-recommended
 
 install:
+  - pip install flake8
   - pip install Sphinx==$SPHINX_VERSION
   - pip install .
 
@@ -23,5 +24,7 @@ install:
 #
 # Provide definition for DOXYGEN variable to stop it trying
 # to run `which doxygen`
-script: make DOXYGEN=doxygen DEBUG=""
+script:
+  - make DOXYGEN=doxygen DEBUG=""
+  - flake8
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -158,7 +158,8 @@ class DoxygenFunctionDirective(BaseDirective):
             # reason (failures in the matcher_stack code) so we consolidate them by shoving them in
             # a set to remove duplicates. Should be fixed!
             for i, entry in enumerate(set(error.signatures)):
-                if i: literal_text += '\n'
+                if i:
+                    literal_text += '\n'
                 # Replace new lines with a new line & enough spacing to reach the appropriate
                 # alignment for our simple plain text list
                 literal_text += '- %s' % entry.replace('\n', '\n  ')
@@ -180,15 +181,16 @@ class DoxygenFunctionDirective(BaseDirective):
             )
         filter_ = self.filter_factory.create_outline_filter(self.options)
 
-        return self.render(node_stack, project_info, self.options, filter_, target_handler, NullMaskFactory())
+        return self.render(node_stack, project_info, self.options, filter_, target_handler,
+                           NullMaskFactory())
 
     def parse_args(self, function_description):
         # Strip off trailing qualifiers
         pattern = re.compile(r'''(?<= \)) \s*
-                                 (?: const)? \s*
-                                 (?: volatile)? \s*
-                                 (?: = \s* 0)? \s* $ ''',
-                                 re.VERBOSE)
+                             (?: const)? \s*
+                             (?: volatile)? \s*
+                             (?: = \s* 0)? \s* $ ''',
+                             re.VERBOSE)
 
         function_description = re.sub(pattern,
                                       '',
@@ -244,14 +246,15 @@ class DoxygenFunctionDirective(BaseDirective):
                 )
             filter_ = self.filter_factory.create_outline_filter(text_options)
             mask_factory = MaskFactory({'param': NoParameterNamesMask})
-            nodes = self.render(entry, project_info, text_options, filter_, target_handler, mask_factory)
+            nodes = self.render(entry, project_info, text_options, filter_, target_handler,
+                                mask_factory)
 
             # Render the nodes to text
             signature = self.text_renderer.render(nodes, self.state.document)
             signatures.append(signature)
 
             match = re.match(r"([^(]*)(.*)", signature)
-            function, match_args = match.group(1), match.group(2)
+            match_args = match.group(2)
 
             # Parse the text to find the arguments
             match_args = self.parse_args(match_args)
@@ -317,7 +320,8 @@ class DoxygenClassLikeDirective(BaseDirective):
         filter_ = self.filter_factory.create_class_filter(name, self.options)
 
         mask_factory = NullMaskFactory()
-        return self.render(matches[0], project_info, self.options, filter_, target_handler, mask_factory)
+        return self.render(matches[0], project_info, self.options, filter_, target_handler,
+                           mask_factory)
 
 
 class DoxygenClassDirective(DoxygenClassLikeDirective):
@@ -385,7 +389,8 @@ class DoxygenContentBlockDirective(BaseDirective):
 
             # Having found the compound node for the namespace or group in the index we want to grab
             # the contents of it which match the filter
-            contents_finder = self.finder_factory.create_finder_from_root(node_stack[0], project_info)
+            contents_finder = self.finder_factory.create_finder_from_root(node_stack[0],
+                                                                          project_info)
             contents = []
             contents_finder.filter_(filter_, contents)
 
@@ -492,7 +497,8 @@ class DoxygenBaseItemDirective(BaseDirective):
 
         node_stack = matches[0]
         mask_factory = NullMaskFactory()
-        return self.render(node_stack, project_info, self.options, filter_, target_handler, mask_factory)
+        return self.render(node_stack, project_info, self.options, filter_, target_handler,
+                           mask_factory)
 
 
 class DoxygenVariableDirective(DoxygenBaseItemDirective):
@@ -844,8 +850,8 @@ class DomainDirectiveFactory(object):
         'typedef': (cpp.CPPTypeObject, 'type'),
         'union': (cpp.CPPTypeObject, 'type'),
         'namespace': (cpp.CPPTypeObject, 'type'),
-        # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for enum values and
-        # CPPMemberObject requires a type.
+        # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for
+        # enum values and CPPMemberObject requires a type.
         'enumvalue': (cpp.CPPClassObject, 'member'),
         'define': (c.CObject, 'macro')
     }
@@ -868,10 +874,12 @@ class DomainDirectiveFactory(object):
         if domain == 'c':
             return c.CObject(*args)
         if domain == 'py':
-            cls, name = DomainDirectiveFactory.python_classes.get(args[0], (python.PyClasslike, 'class'))
+            cls, name = DomainDirectiveFactory.python_classes.get(
+                args[0], (python.PyClasslike, 'class'))
             args[1] = [DomainDirectiveFactory.fix_python_signature(n) for n in args[1]]
         else:
-            cls, name = DomainDirectiveFactory.cpp_classes.get(args[0], (cpp.CPPMemberObject, 'member'))
+            cls, name = DomainDirectiveFactory.cpp_classes.get(
+                args[0], (cpp.CPPMemberObject, 'member'))
         # Replace the directive name because domain directives don't know how to handle
         # Breathe's "doxygen" directives.
         args = [name] + args[1:]
@@ -1038,4 +1046,3 @@ def setup(app):
     app.connect("env-get-outdated", file_state_cache.get_outdated)
 
     app.connect("env-purge-doc", file_state_cache.purge_doc)
-

--- a/breathe/process.py
+++ b/breathe/process.py
@@ -17,6 +17,7 @@ ALIASES = "rst=\verbatim embed:rst"
 ALIASES += "endrst=\endverbatim"
 """.strip()
 
+
 class ProjectData(object):
     "Simple handler for the files and project_info for each project"
 
@@ -24,6 +25,7 @@ class ProjectData(object):
 
         self.auto_project_info = auto_project_info
         self.files = files
+
 
 class AutoDoxygenProcessHandle(object):
 
@@ -45,7 +47,7 @@ class AutoDoxygenProcessHandle(object):
             contents = file_structure[1]
 
             auto_project_info = self.project_info_factory.create_auto_project_info(
-                    project_name, folder)
+                project_name, folder)
 
             project_files[project_name] = ProjectData(auto_project_info, contents)
 
@@ -83,4 +85,3 @@ class AutoDoxygenProcessHandle(object):
         self.run_process(['doxygen', cfgfile], cwd=build_dir)
 
         return self.path_handler.join(build_dir, name, "xml")
-

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -3,11 +3,14 @@ from .exception import BreatheError
 
 import os
 
+
 class ProjectError(BreatheError):
     pass
 
+
 class NoDefaultProjectError(ProjectError):
     pass
+
 
 class AutoProjectInfo(object):
     """Created as a temporary step in the automatic xml generation process"""
@@ -34,7 +37,6 @@ class AutoProjectInfo(object):
         self._domain_by_extension = domain_by_extension
         self._domain_by_file_pattern = domain_by_file_pattern
         self._match = match
-
 
     def name(self):
         return self._name
@@ -65,6 +67,7 @@ class AutoProjectInfo(object):
             self._domain_by_file_pattern,
             self._match
             )
+
 
 class ProjectInfo(object):
 
@@ -103,16 +106,17 @@ class ProjectInfo(object):
     def relative_path_to_xml_file(self, file_):
         """
         Returns relative path from Sphinx documentation top-level source directory to the specified
-        file assuming that the specified file is a path relative to the doxygen xml output directory.
+        file assuming that the specified file is a path relative to the doxygen xml output
+        directory.
         """
 
         # os.path.join does the appropriate handling if _project_path is an absolute path
         full_xml_project_path = os.path.join(self._config_dir, self._project_path, file_)
 
         return os.path.relpath(
-                full_xml_project_path,
-                self._source_dir
-                )
+            full_xml_project_path,
+            self._source_dir
+        )
 
     def sphinx_abs_path_to_file(self, file_):
         """
@@ -187,17 +191,17 @@ class ProjectInfoFactory(object):
 
         if not self.default_project:
             raise NoDefaultProjectError(
-                    "No breathe_default_project config setting to fall back on "
-                    "for directive with no 'project' or 'path' specified."
-                    )
+                "No breathe_default_project config setting to fall back on "
+                "for directive with no 'project' or 'path' specified."
+            )
 
         try:
             return self.projects[self.default_project]
         except KeyError:
             raise ProjectError(
-                    ( "breathe_default_project value '%s' does not seem to be a valid key for the "
-                      "breathe_projects dictionary" ) % self.default_project
-                    )
+                ("breathe_default_project value '%s' does not seem to be a valid key for the "
+                 "breathe_projects dictionary") % self.default_project
+            )
 
     def create_project_info(self, options):
 
@@ -208,7 +212,8 @@ class ProjectInfoFactory(object):
                 path = self.projects[options["project"]]
                 name = options["project"]
             except KeyError:
-                raise ProjectError( "Unable to find project '%s' in breathe_projects dictionary" % options["project"] )
+                raise ProjectError("Unable to find project '%s' in breathe_projects dictionary"
+                                   % options["project"])
 
         elif "path" in options:
             path = options["path"]
@@ -228,16 +233,16 @@ class ProjectInfoFactory(object):
                 self.project_count += 1
 
             project_info = ProjectInfo(
-                    name,
-                    path,
-                    "NoSourcePath",
-                    reference,
-                    self.source_dir,
-                    self.config_dir,
-                    self.domain_by_extension,
-                    self.domain_by_file_pattern,
-                    self.match
-                    )
+                name,
+                path,
+                "NoSourcePath",
+                reference,
+                self.source_dir,
+                self.config_dir,
+                self.domain_by_extension,
+                self.domain_by_file_pattern,
+                self.match
+            )
 
             self.project_info_store[path] = project_info
 
@@ -263,9 +268,9 @@ class ProjectInfoFactory(object):
 
         if name is None:
             raise NoDefaultProjectError(
-                    "No breathe_default_project config setting to fall back on "
-                    "for directive with no 'project' or 'path' specified."
-                    )
+                "No breathe_default_project config setting to fall back on "
+                "for directive with no 'project' or 'path' specified."
+            )
 
         return self.project_info_for_auto_store[name]
 
@@ -285,16 +290,16 @@ class ProjectInfoFactory(object):
                 self.project_count += 1
 
             auto_project_info = AutoProjectInfo(
-                    name,
-                    source_path,
-                    self.build_dir,
-                    reference,
-                    self.source_dir,
-                    self.config_dir,
-                    self.domain_by_extension,
-                    self.domain_by_file_pattern,
-                    self.match
-                    )
+                name,
+                source_path,
+                self.build_dir,
+                reference,
+                self.source_dir,
+                self.config_dir,
+                self.domain_by_extension,
+                self.domain_by_file_pattern,
+                self.match
+            )
 
             self.auto_project_info_store[key] = auto_project_info
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,4 @@
 
-# Ignore:
-#   W391 - Blank lines at the end of the file
-#   E123 - Closing bracket does not match indentation of open bracket's line
 [flake8]
-ignore = W391,E123
 max-line-length = 100
+exclude=compoundsuper.py,indexsuper.py


### PR DESCRIPTION
Hi @vitaut,

I thought I'd take a stab at getting travis to test both Sphinx 1.2.* and 1.3.* which seems to be working brilliantly thanks to your work.

I then thought we could start introducing `flake8` checks to try to keep the code closer to PEP-8 compliance. I'm sorry I never took it that seriously in the early days of the project so there is a bit of debt to work through. I've started off with a subset of files with the hope of expanding that group as we work on them.

One trouble with lots of white space PEP-8 related changes is that it plays havoc with merges. I'm not sure if you're currently working on anything but if you are and it clashes please feel free to merge or rebase in a way which keeps all your changes and loses this for the moment. There are no logic changes here so it is much easier to redo PEP-8 compliance than actually useful code.

Cheers,
Michael