### PR TITLE
Only add breathe stylesheet if it is available

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -1028,7 +1028,9 @@ def setup(app):
     app.add_config_value("breathe_default_members", (), True)
     app.add_config_value("breathe_implementation_filename_extensions", ['.c', '.cc', '.cpp'], True)
 
-    app.add_stylesheet("breathe.css")
+    breathe_css = "breathe.css"
+    if (os.path.exists(os.path.join(app.confdir, "_static", breathe_css))):
+        app.add_stylesheet(breathe_css)
 
     doxygen_handle = AutoDoxygenProcessHandle(
         path_handler,


### PR DESCRIPTION
The proposed PR fixes #134 by adding `breathe.css` only if it is present in the `_static` directory. Otherwise the default theme styles apply. Anyone who wants to use Breathe styles can do this by copying `breathe.css` to the `_static` directory manually which needs to be done anyway since it is not done automatically.