### PR TITLE
Add basic unit test for parameter code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 
 install:
   - pip install flake8
+  - pip install nose
   - pip install Sphinx==$SPHINX_VERSION
   - pip install .
 
@@ -26,5 +27,6 @@ install:
 # to run `which doxygen`
 script:
   - make DOXYGEN=doxygen DEBUG=""
-  - flake8 breathe/*.py
+  - make tests
+  - make flake8
 

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,8 @@ clean:
 test:
 	cd tests && nosetests
 
+dev-test:
+	cd tests && PYTHONPATH=../:$(PTYONPATH) nosetests
+
 flake8:
 	flake8 breathe/*.py

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,8 @@ clean:
 	$(MAKE) -C examples/tinyxml $@
 	$(MAKE) -C examples/specific $@
 
+test:
+	cd tests && nosetests
+
+flake8:
+	flake8 breathe/*.py

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -614,11 +614,6 @@ class DoxygenDirectiveFactory(object):
         self.target_handler_factory = target_handler_factory
         self.parser_factory = parser_factory
 
-    # TODO: This methods should be scrapped as they are only called in one place. We should just
-    # inline the code at the call site
-    def create_index_directive_container(self):
-        return self.create_directive_container("doxygenindex")
-
     def create_function_directive_container(self):
 
         # Pass text_renderer to the function directive
@@ -634,45 +629,6 @@ class DoxygenDirectiveFactory(object):
             self.target_handler_factory,
             self.parser_factory
             )
-
-    def create_struct_directive_container(self):
-        return self.create_directive_container("doxygenstruct")
-
-    def create_enum_directive_container(self):
-        return self.create_directive_container("doxygenenum")
-
-    def create_enumvalue_directive_container(self):
-        return self.create_directive_container("doxygenenumvalue")
-
-    def create_typedef_directive_container(self):
-        return self.create_directive_container("doxygentypedef")
-
-    def create_union_directive_container(self):
-        return self.create_directive_container("doxygenunion")
-
-    def create_class_directive_container(self):
-        return self.create_directive_container("doxygenclass")
-
-    def create_file_directive_container(self):
-        return self.create_directive_container("doxygenfile")
-
-    def create_namespace_directive_container(self):
-        return self.create_directive_container("doxygennamespace")
-
-    def create_group_directive_container(self):
-        return self.create_directive_container("doxygengroup")
-
-    def create_variable_directive_container(self):
-        return self.create_directive_container("doxygenvariable")
-
-    def create_define_directive_container(self):
-        return self.create_directive_container("doxygendefine")
-
-    def create_auto_index_directive_container(self):
-        return self.create_directive_container("autodoxygenindex")
-
-    def create_auto_file_directive_container(self):
-        return self.create_directive_container("autodoxygenfile")
 
     def create_directive_container(self, type_):
 
@@ -943,79 +899,27 @@ def setup(app):
 
     DoxygenFunctionDirective.app = app
 
-    app.add_directive(
-        "doxygenindex",
-        directive_factory.create_index_directive_container(),
-        )
+    def add_directive(name):
+        app.add_directive(name, directive_factory.create_directive_container(name))
+
+    add_directive('doxygenindex')
+    add_directive('doxygenstruct')
+    add_directive('doxygenenum')
+    add_directive('doxygenenumvalue')
+    add_directive('doxygentypedef')
+    add_directive('doxygenunion')
+    add_directive('doxygenclass')
+    add_directive('doxygenfile')
+    add_directive('doxygennamespace')
+    add_directive('doxygengroup')
+    add_directive('doxygenvariable')
+    add_directive('doxygendefine')
+    add_directive('autodoxygenindex')
+    add_directive('autodoxygenfile')
 
     app.add_directive(
         "doxygenfunction",
         directive_factory.create_function_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenstruct",
-        directive_factory.create_struct_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenenum",
-        directive_factory.create_enum_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenenumvalue",
-        directive_factory.create_enumvalue_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygentypedef",
-        directive_factory.create_typedef_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenunion",
-        directive_factory.create_union_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenclass",
-        directive_factory.create_class_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenfile",
-        directive_factory.create_file_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygennamespace",
-        directive_factory.create_namespace_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygengroup",
-        directive_factory.create_group_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygenvariable",
-        directive_factory.create_variable_directive_container(),
-        )
-
-    app.add_directive(
-        "doxygendefine",
-        directive_factory.create_define_directive_container(),
-        )
-
-    app.add_directive(
-        "autodoxygenindex",
-        directive_factory.create_auto_index_directive_container(),
-        )
-
-    app.add_directive(
-        "autodoxygenfile",
-        directive_factory.create_auto_file_directive_container(),
         )
 
     app.add_config_value("breathe_projects", {}, True)

--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -223,6 +223,28 @@ class MemberDefTypeSubRenderer(Renderer):
         return nodes
 
 
+def get_param_decl(param):
+
+    param_type = []
+    for p in param.type_.content_:
+        value = p.value
+        if not isinstance(value, unicode):
+            value = value.valueOf_
+        param_type.append(value)
+    param_type = ' '.join(param_type)
+    param_name = param.declname if param.declname else param.defname
+    if not param_name:
+        param_decl = param_type
+    elif '(*)' in param_type:
+        param_decl = param_type.replace('(*)', '(*' + param_name + ')')
+    else:
+        param_decl = param_type + ' ' + param_name
+    if param.array:
+        param_decl += param.array
+
+    return param_decl
+
+
 class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
     def update_signature(self, signode):
@@ -247,27 +269,12 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
     def render(self):
         # Get full function signature for the domain directive.
-        params = []
+        param_list = []
         for param in self.data_object.param:
             param = self.context.mask_factory.mask(param)
-            param_type = []
-            for p in param.type_.content_:
-                value = p.value
-                if not isinstance(value, unicode):
-                    value = value.valueOf_
-                param_type.append(value)
-            param_type = ' '.join(param_type)
-            param_name = param.declname if param.declname else param.defname
-            if not param_name:
-                param_decl = param_type
-            elif '(*)' in param_type:
-                param_decl = param_type.replace('(*)', '(*' + param_name + ')')
-            else:
-                param_decl = param_type + ' ' + param_name
-            if param.array:
-                param_decl += param.array
-            params.append(param_decl)
-        signature = '{0}({1})'.format(self.data_object.definition, ', '.join(params))
+            param_decl = get_param_decl(param)
+            param_list.append(param_decl)
+        signature = '{0}({1})'.format(self.data_object.definition, ', '.join(param_list))
         # Remove 'virtual' keyword as Sphinx 1.2 doesn't support virtual functions.
         virtual = 'virtual '
         if signature.startswith(virtual):

--- a/examples/doxygen/afterdoc.h
+++ b/examples/doxygen/afterdoc.h
@@ -1,6 +1,6 @@
 /*! A test class */
 
-class Test
+class Test1
 {
   public:
     /** An enum type. 

--- a/examples/doxygen/autolink.cpp
+++ b/examples/doxygen/autolink.cpp
@@ -1,33 +1,33 @@
 /*! \file autolink.cpp
   Testing automatic link generation.
   
-  A link to a member of the Test class: Test::member, 
+  A link to a member of the Test2 class: Test2::member,
   
   More specific links to the each of the overloaded members:
-  Test::member(int) and Test#member(int,int)
+  Test2::member(int) and Test2#member(int,int)
 
-  A link to a protected member variable of Test: Test#var, 
+  A link to a protected member variable of Test2: Test2#var,
 
   A link to the global enumeration type #GlobEnum.
  
   A link to the define #ABS(x).
   
-  A link to the destructor of the Test class: Test::~Test, 
+  A link to the destructor of the Test2 class: Test2::~Test2,
   
-  A link to the typedef ::B.
+  A link to the typedef ::Test2TypeDef.
  
-  A link to the enumeration type Test::EType
+  A link to the enumeration type Test2::EType
   
-  A link to some enumeration values Test::Val1 and ::GVal2
+  A link to some enumeration values Test2::Val1 and ::GVal2
 */
 
 /*!
-  Since this documentation block belongs to the class Test no link to 
-  Test is generated.
+  Since this documentation block belongs to the class Test2 no link to
+  Test2 is generated.
 
-  Two ways to link to a constructor are: #Test and Test().
+  Two ways to link to a constructor are: #Test2 and Test2().
 
-  Links to the destructor are: #~Test and ~Test().
+  Links to the destructor are: #~Test2 and ~Test2().
   
   A link to a member in this class: member().
 
@@ -36,7 +36,7 @@
   
   A link to the variable #var.
 
-  A link to the global typedef ::B.
+  A link to the global typedef ::Test2TypeDef.
 
   A link to the global enumeration type #GlobEnum.
   
@@ -46,19 +46,19 @@
   
   A link to the enumeration type #EType.
 
-  A link to some enumeration values: \link Test::Val1 Val1 \endlink and ::GVal1.
+  A link to some enumeration values: \link Test2::Val1 Val1 \endlink and ::GVal1.
 
   And last but not least a link to a file: autolink.cpp.
   
   \sa Inside a see also section any word is checked, so EType, 
-      Val1, GVal1, ~Test and member will be replaced by links in HTML.
+      Val1, GVal1, ~Test2 and member will be replaced by links in HTML.
 */
 
-class Test
+class Test2
 {
   public:
-    Test();               //!< constructor 
-   ~Test();               //!< destructor 
+    Test2();               //!< constructor
+   ~Test2();               //!< destructor
     void member(int);     /**< A member function. Details. */
     void member(int,int); /**< An overloaded member function. Details */
 
@@ -73,10 +73,10 @@ class Test
 };
 
 /*! details. */
-Test::Test() { }
+Test2::Test2() { }
 
 /*! details. */
-Test::~Test() { }
+Test2::~Test2() { }
 
 /*! A global variable. */
 int globVar;
@@ -92,8 +92,8 @@ enum GlobEnum {
  */ 
 #define ABS(x) (((x)>0)?(x):-(x))
 
-typedef Test B;
+typedef Test2 Test2TypeDef;
 
-/*! \fn typedef Test B
+/*! \fn typedef Test2 Test2TypeDef
  *  A type definition. 
  */

--- a/examples/doxygen/class.h
+++ b/examples/doxygen/class.h
@@ -1,6 +1,6 @@
 /* A dummy class */
 
-class Test
+class Test3
 {
 };
 

--- a/examples/doxygen/enum.h
+++ b/examples/doxygen/enum.h
@@ -1,4 +1,4 @@
-class Test
+class Test4
 {
   public:
     enum TEnum { Val1, Val2 };
@@ -11,14 +11,14 @@ class Test
     };
 };
 
-/*! \class Test
+/*! \class Test4
  * The class description.
  */
 
-/*! \enum Test::TEnum
+/*! \enum Test4::TEnum
  * A description of the enum type.
  */
 
-/*! \var Test::TEnum Test::Val1
+/*! \var Test4::TEnum Test4::Val1
  * The description of the first enum value.
  */

--- a/examples/doxygen/example.cpp
+++ b/examples/doxygen/example.cpp
@@ -1,8 +1,8 @@
-/** A Test class.
+/** A Test5 class.
  *  More details about this class.
  */
 
-class Test
+class Test5
 {
   public:
     /** An example member function.
@@ -11,9 +11,9 @@ class Test
     void example();
 };
 
-void Test::example() {}
+void Test5::example() {}
 
 /** \example example_test.cpp
- * This is an example of how to use the Test class.
+ * This is an example of how to use the Test5 class.
  * More details about this example.
  */

--- a/examples/doxygen/example.tag
+++ b/examples/doxygen/example.tag
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
 <tagfile>
   <compound kind="class">
-    <name>Test</name>
-    <filename>class_test.html</filename>
+    <name>Test5</name>
+    <filename>class_test5.html</filename>
     <member kind="function">
       <type>void</type>
       <name>example</name>
-      <anchorfile>class_test.html</anchorfile>
-      <anchor>a47b775f65718978f1ffcd96376f8ecfa</anchor>
+      <anchorfile>class_test5.html</anchorfile>
+      <anchor>abf3ec2f0f7f2e0d18a212625caa090b7</anchor>
       <arglist>()</arglist>
     </member>
   </compound>

--- a/examples/doxygen/example_test.cpp
+++ b/examples/doxygen/example_test.cpp
@@ -1,5 +1,5 @@
 void main()
 {
-  Test t;
+  Test7 t;
   t.example();
 }

--- a/examples/doxygen/func.h
+++ b/examples/doxygen/func.h
@@ -1,18 +1,18 @@
-class Test
+class Test6
 {
   public:
     const char *member(char,int) throw(std::out_of_range);
 };
 
-const char *Test::member(char c,int n) throw(std::out_of_range) {}
+const char *Test6::member(char c,int n) throw(std::out_of_range) {}
 
-/*! \class Test
- * \brief Test class.
+/*! \class Test6
+ * \brief Test6 class.
  *
- * Details about Test.
+ * Details about Test6.
  */
 
-/*! \fn const char *Test::member(char c,int n) 
+/*! \fn const char *Test6::member(char c,int n)
  *  \brief A member function.
  *  \param c a character.
  *  \param n an integer.

--- a/examples/doxygen/group.cpp
+++ b/examples/doxygen/group.cpp
@@ -10,7 +10,7 @@ class C1 {};
 class C2 {};
 
 /** function in group 1 */
-void func() {}
+void func1() {}
 
 /** @} */ // end of group1
 

--- a/examples/doxygen/include.cpp
+++ b/examples/doxygen/include.cpp
@@ -1,7 +1,7 @@
 
 /*! A test class. */
 
-class Test
+class Test7
 {
   public:
     /// a member function
@@ -13,8 +13,8 @@ class Test
  *  Our main function starts like this:
  *  \skip main
  *  \until {
- *  First we create a object \c t of the Test class.
- *  \skipline Test
+ *  First we create a object \c t of the Test7 class.
+ *  \skipline Test7
  *  Then we call the example member function 
  *  \line example
  *  After that our little test routine ends.

--- a/examples/doxygen/jdstyle.cpp
+++ b/examples/doxygen/jdstyle.cpp
@@ -2,7 +2,7 @@
  *  A test class. A more elaborate class description.
  */
 
-class Test
+class Test8
 {
   public:
 
@@ -23,20 +23,20 @@ class Test
        * A constructor.
        * A more elaborate description of the constructor.
        */
-      Test();
+      Test8();
 
       /**
        * A destructor.
        * A more elaborate description of the destructor.
        */
-     ~Test();
+     ~Test8();
     
       /**
        * a normal member taking two arguments and returning an integer value.
        * @param a an integer argument.
        * @param s a constant character pointer.
-       * @see Test()
-       * @see ~Test()
+       * @see Test8()
+       * @see ~Test8()
        * @see testMeToo()
        * @see publicVar()
        * @return The test results

--- a/examples/doxygen/memgrp.cpp
+++ b/examples/doxygen/memgrp.cpp
@@ -1,5 +1,5 @@
 /** A class. Details */
-class Test
+class Test9
 {
   public:
     //@{
@@ -15,17 +15,17 @@ class Test
     void func2InGroup2();
 };
 
-void Test::func1InGroup1() {}
-void Test::func2InGroup1() {}
+void Test9::func1InGroup1() {}
+void Test9::func2InGroup1() {}
 
 /** @name Group2
  *  Description of group 2. 
  */
 //@{
 /** Function 2 in group 2. Details. */
-void Test::func2InGroup2() {}
+void Test9::func2InGroup2() {}
 /** Function 1 in group 2. Details. */
-void Test::func1InGroup2() {}
+void Test9::func1InGroup2() {}
 //@}
 
 /*! \file 

--- a/examples/doxygen/overload.cpp
+++ b/examples/doxygen/overload.cpp
@@ -1,25 +1,25 @@
-class Test 
+class Test10
 {
   public:
     void drawRect(int,int,int,int);
     void drawRect(const Rect &r);
 };
 
-void Test::drawRect(int x,int y,int w,int h) {}
-void Test::drawRect(const Rect &r) {}
+void Test10::drawRect(int x,int y,int w,int h) {}
+void Test10::drawRect(const Rect &r) {}
 
-/*! \class Test
+/*! \class Test10
  *  \brief A short description.
  *   
  *  More text.
  */
 
-/*! \fn void Test::drawRect(int x,int y,int w,int h)
+/*! \fn void Test10::drawRect(int x,int y,int w,int h)
  * This command draws a rectangle with a left upper corner at ( \a x , \a y ),
  * width \a w and height \a h. 
  */
 
 /*!
- * \overload void Test::drawRect(const Rect &r)
+ * \overload void Test10::drawRect(const Rect &r)
  */
 

--- a/examples/doxygen/par.cpp
+++ b/examples/doxygen/par.cpp
@@ -1,4 +1,4 @@
-/*! \class Test
+/*! \class Test11
  * Normal text.
  *
  * \par User defined paragraph:
@@ -17,4 +17,4 @@
  * More normal text. 
  */
   
-class Test {};
+class Test11 {};

--- a/examples/doxygen/qtstyle.cpp
+++ b/examples/doxygen/qtstyle.cpp
@@ -3,7 +3,7 @@
   A more elaborate class description.
 */
 
-class Test
+class Test12
 {
   public:
 
@@ -25,20 +25,20 @@ class Test
     /*!
       A more elaborate description of the constructor.
     */
-    Test();
+    Test12();
 
     //! A destructor.
     /*!
       A more elaborate description of the destructor.
     */
-   ~Test();
+   ~Test12();
     
     //! A normal member taking two arguments and returning an integer value.
     /*!
       \param a an integer argument.
       \param s a constant character pointer.
       \return The test results
-      \sa Test(), ~Test(), testMeToo() and publicVar()
+      \sa Test12(), ~Test12(), testMeToo() and publicVar()
     */
     int testMe(int a,const char *s);
        

--- a/examples/doxygen/tag.cpp
+++ b/examples/doxygen/tag.cpp
@@ -1,7 +1,7 @@
-/*! A class that is inherited from the external class Test.
+/*! A class that is inherited from the external class Test13.
 */
 
-class Tag : public Test
+class Tag : public Test13
 {
   public:
     /*! an overloaded member. */

--- a/examples/doxygen/templ.cpp
+++ b/examples/doxygen/templ.cpp
@@ -1,35 +1,35 @@
 
 /*! A template class */
-template<class T,int i=100> class Test
+template<class T,int i=100> class Test14
 {
   public:
-    Test();
-    Test(const Test &);
+    Test14();
+    Test14(const Test14 &);
 };
 
 /*! complete specialization */
-template<> class Test<void *,200>
+template<> class Test14<void *,200>
 {
   public:
-    Test();
+    Test14();
 };
 
 /*! A partial template specialization */
-template<class T> class Test<T *> : public Test<void *,200>
+template<class T> class Test14<T *> : public Test14<void *,200>
 {
   public:
-    Test();
+    Test14();
 };
 
 /*! The constructor of the template class*/
-template<class T,int i> Test<T,i>::Test() {}
+template<class T,int i> Test14<T,i>::Test14() {}
 
 /*! The copy constructor */
-template<class T,int i> Test<T,i>::Test(const Test &t) {}
+template<class T,int i> Test14<T,i>::Test14(const Test14 &t) {}
 
 /*! The constructor of the partial specialization */
-template<class T> Test<T *>::Test() {}
+template<class T> Test14<T *>::Test14() {}
 
 /*! The constructor of the specialization */
-template<> Test<void *,200>::Test() {}
+template<> Test14<void *,200>::Test14() {}
 

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -20,7 +20,7 @@ HAVE_DOT  = /usr/bin/dot
 
 projects  = nutshell alias rst inline namespacefile c_file array \
 			members userdefined fixedwidthfont latexmath functionOverload \
-			image name union group struct qtslots lists headings links \
+			image name union group struct qtslots lists headings links parameters \
 			template_class template_class_non_type template_function template_specialisation enum
 
 special   = programlisting decl_impl multifilexml auto class typedef

--- a/examples/specific/parameters.cfg
+++ b/examples/specific/parameters.cfg
@@ -1,0 +1,13 @@
+# For a case where Breathe was failing on the doxygen output
+
+PROJECT_NAME     = "Parameters Test"
+OUTPUT_DIRECTORY = parameters
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = parameters.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES

--- a/examples/specific/parameters.h
+++ b/examples/specific/parameters.h
@@ -1,0 +1,3 @@
+
+/*! My function */
+int f(int (*p)[3]);

--- a/examples/specific/parameters.h
+++ b/examples/specific/parameters.h
@@ -1,3 +1,8 @@
 
 /*! My function */
-int f(int (*p)[3]);
+int f(int a, float b, int* c, int (*p)[3]);
+
+class MyClass {};
+
+int g(MyClass a, MyClass* b);
+

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export PYTHONPATH=../
+
+nosetests

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from xml.dom import minidom
 
 from breathe.renderer.rst.doxygen.compound import get_param_decl
 from breathe.parser.doxygen.compoundsuper import memberdefType
+from breathe.directives import PathHandler
 
 class TestUtils(TestCase):
 
@@ -52,3 +53,14 @@ class TestUtils(TestCase):
         self.assertEqual(get_param_decl(memberdef.param[3]), 'int(*p)[3]')
         self.assertEqual(get_param_decl(memberdef.param[4]), 'MyClass a')
         self.assertEqual(get_param_decl(memberdef.param[5]), 'MyClass  * b')
+
+
+class TestPathHandler(TestCase):
+
+    def test_path_handler(self):
+
+        path_handler = PathHandler(None, None, None, None)
+
+        self.assertEqual(path_handler.includes_directory('directory/file.h'), True)
+        self.assertEqual(path_handler.includes_directory('directory\\file.h'), True)
+        self.assertEqual(path_handler.includes_directory('file.h'), False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+
+from unittest import TestCase
+from xml.dom import minidom
+
+from breathe.renderer.rst.doxygen.compound import get_param_decl
+from breathe.parser.doxygen.compoundsuper import memberdefType
+
+class TestUtils(TestCase):
+
+    def test_param_decl(self):
+
+        # From declaration:
+        #    int f(int (*p)[3]);
+        # in: examples/specific/parameters.h
+        xml = """
+        <param>
+          <type>int(*)</type>
+          <declname>p</declname>
+          <array>[3]</array>
+        </param>
+        """
+
+        doc = minidom.parseString(xml)
+
+        memberdef = memberdefType.factory()
+        memberdef.buildChildren(doc.documentElement, 'param')
+
+        self.assertEqual(get_param_decl(memberdef.param[0]), 'int(*p)[3]')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,20 +9,46 @@ class TestUtils(TestCase):
 
     def test_param_decl(self):
 
-        # From declaration:
-        #    int f(int (*p)[3]);
-        # in: examples/specific/parameters.h
+        # From xml from: examples/specific/parameters.h
         xml = """
+        <memberdef>
+        <param>
+          <type>int</type>
+          <declname>a</declname>
+        </param>
+        <param>
+          <type>float</type>
+          <declname>b</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>c</declname>
+        </param>
         <param>
           <type>int(*)</type>
           <declname>p</declname>
           <array>[3]</array>
         </param>
+        <param>
+          <type><ref refid="class_my_class" kindref="compound">MyClass</ref></type>
+          <declname>a</declname>
+        </param>
+        <param>
+          <type><ref refid="class_my_class" kindref="compound">MyClass</ref> *</type>
+          <declname>b</declname>
+        </param>
+        </memberdef>
         """
 
         doc = minidom.parseString(xml)
 
         memberdef = memberdefType.factory()
-        memberdef.buildChildren(doc.documentElement, 'param')
+        for child in doc.documentElement.childNodes:
+            memberdef.buildChildren(child, 'param')
 
-        self.assertEqual(get_param_decl(memberdef.param[0]), 'int(*p)[3]')
+        self.assertEqual(get_param_decl(memberdef.param[0]), 'int a')
+        self.assertEqual(get_param_decl(memberdef.param[1]), 'float b')
+        self.assertEqual(get_param_decl(memberdef.param[2]), 'int * c')
+        self.assertEqual(get_param_decl(memberdef.param[3]), 'int(*p)[3]')
+        self.assertEqual(get_param_decl(memberdef.param[4]), 'MyClass a')
+        self.assertEqual(get_param_decl(memberdef.param[5]), 'MyClass  * b')


### PR DESCRIPTION
Hi @vitaut,

This is a very basic effort to have a unit test for the parameter code. I've separated it into a pure function that can be tested easily and then set up a test to exercise the code based off some example xml.

I think it'll help us test some parts of the code in a more reliable way than us trying to check the diff with the last html. Needs more work to test more complex examples as this doesn't deal with getting rst nodes and rendering them to html and checking the result of that. But it is a start.

I'm also out of touch on the best unit test framework to go with. I've started with nosetest as it has a feature for re-running only the failing tests which I quite like. nose2 didn't have that when I last checked unfortunately but I don't know much about py.test or other options.

I might keep this branch open until I've add more than one test :) And added the necessary lines to get travis to run it.

Cheers,
Michael

 