### PR TITLE
Adding html and pdf build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 
-all: data
+all: html pdf
+
+html: data
 	$(MAKE) -C documentation html
+
+pdf: data
 	$(MAKE) -C documentation latexpdf
 	
 data:


### PR DESCRIPTION
html and pdf build targets allow for building just one form of the documentation