### PR TITLE
Remove template arguments from the class name in the member function

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -249,6 +249,8 @@ def get_definition_without_template_args(data_object):
     """
     Return data_object.definition removing any template arguments from the class name in the member function.
     Otherwise links to classes defined in the same template are not generated correctly.
+
+    For example in 'Result<T> A< B<C> >::f' we want to remove the '< B<C> >' part.
     """
     definition = data_object.definition
     qual_name = '::' + data_object.name
@@ -257,6 +259,8 @@ def get_definition_without_template_args(data_object):
         pos = qual_name_start - 1
         if definition[pos] == '>':
             bracket_count = 0
+            # Iterate back through the characters of the definition counting matching braces and
+            # then remove all braces and everything between
             while pos > 0:
                 if definition[pos] == '>':
                     bracket_count += 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,21 +54,20 @@ class TestUtils(TestCase):
         self.assertEqual(get_param_decl(memberdef.param[4]), 'MyClass a')
         self.assertEqual(get_param_decl(memberdef.param[5]), 'MyClass  * b')
 
-
     def test_definition_without_template_args(self):
 
-      def get_definition(definition, name):
-        class MockDataObject:
-            def __init__(self, definition, name):
-              self.definition = definition
-              self.name = name
-        return get_definition_without_template_args(MockDataObject(definition, name))
+        def get_definition(definition, name):
+            class MockDataObject:
+                def __init__(self, definition, name):
+                    self.definition = definition
+                    self.name = name
+            return get_definition_without_template_args(MockDataObject(definition, name))
 
-      self.assertEqual('void A::foo', get_definition('void A<T>::foo', 'foo'))
-      # Template arguments in the return type should be preserved:
-      self.assertEqual('Result<T> A::f', get_definition('Result<T> A::f', 'f'))
-      # Nested template arguments:
-      self.assertEqual('Result<T> A::f', get_definition('Result<T> A< B<C> >::f', 'f'))
+        self.assertEqual('void A::foo', get_definition('void A<T>::foo', 'foo'))
+        # Template arguments in the return type should be preserved:
+        self.assertEqual('Result<T> A::f', get_definition('Result<T> A::f', 'f'))
+        # Nested template arguments:
+        self.assertEqual('Result<T> A::f', get_definition('Result<T> A< B<C> >::f', 'f'))
 
 
 class TestPathHandler(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 from xml.dom import minidom
 
-from breathe.renderer.rst.doxygen.compound import get_param_decl
+from breathe.renderer.rst.doxygen.compound import get_param_decl, get_definition_without_template_args
 from breathe.parser.doxygen.compoundsuper import memberdefType
 from breathe.directives import PathHandler
 
@@ -53,6 +53,22 @@ class TestUtils(TestCase):
         self.assertEqual(get_param_decl(memberdef.param[3]), 'int(*p)[3]')
         self.assertEqual(get_param_decl(memberdef.param[4]), 'MyClass a')
         self.assertEqual(get_param_decl(memberdef.param[5]), 'MyClass  * b')
+
+
+    def test_definition_without_template_args(self):
+
+      def get_definition(definition, name):
+        class MockDataObject:
+            def __init__(self, definition, name):
+              self.definition = definition
+              self.name = name
+        return get_definition_without_template_args(MockDataObject(definition, name))
+
+      self.assertEqual('void A::foo', get_definition('void A<T>::foo', 'foo'))
+      # Template arguments in the return type should be preserved:
+      self.assertEqual('Result<T> A::f', get_definition('Result<T> A::f', 'f'))
+      # Nested template arguments:
+      self.assertEqual('Result<T> A::f', get_definition('Result<T> A< B<C> >::f', 'f'))
 
 
 class TestPathHandler(TestCase):


### PR DESCRIPTION
The proposed PR removes template arguments from the class name in the member function. Otherwise links to nested classes (in parameter or return types) defined in the same template are not generated correctly, because the latter don't include template arguments.

For example, `void C<T>::f(D)` is converted to `void C::f(D)` in

```c++
/** A class */
template <typename T>
class C {
 public:
  /** An inner class. */
  class D {};

  /** A method. */
  void f(D);
};
```

Fixes #179.

@michaeljones, if you merged #189 first, I could also add a unit test for this.