### PR TITLE
Fix handling of array references in parameters

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -237,6 +237,8 @@ def get_param_decl(param):
         param_decl = param_type
     elif '(*)' in param_type:
         param_decl = param_type.replace('(*)', '(*' + param_name + ')')
+    elif '(&)' in param_type:
+        param_decl = param_type.replace('(&)', '(&' + param_name + ')')
     else:
         param_decl = param_type + ' ' + param_name
     if param.array:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,11 @@ class TestUtils(TestCase):
           <type><ref refid="class_my_class" kindref="compound">MyClass</ref> *</type>
           <declname>b</declname>
         </param>
+        <param>
+          <type>int(&amp;)</type>
+          <declname>r</declname>
+          <array>[3]</array>
+        </param>
         </memberdef>
         """
 
@@ -53,6 +58,7 @@ class TestUtils(TestCase):
         self.assertEqual(get_param_decl(memberdef.param[3]), 'int(*p)[3]')
         self.assertEqual(get_param_decl(memberdef.param[4]), 'MyClass a')
         self.assertEqual(get_param_decl(memberdef.param[5]), 'MyClass  * b')
+        self.assertEqual(get_param_decl(memberdef.param[6]), 'int(&r)[3]')
 
     def test_definition_without_template_args(self):
 


### PR DESCRIPTION
The proposed patch fixes handling of array references in parameters like `int(&r)[3]`. As with pointers, Doxygen passes parameter name `r` separately from type `int(&)[3]`, so we need to combine them ourselves to form a valid parameter declaration.