### PR TITLE
Change template parameters to be labeled as such.

### DIFF
--- a/breathe/renderer/rst/doxygen/compound.py
+++ b/breathe/renderer/rst/doxygen/compound.py
@@ -627,7 +627,7 @@ class DocParamListTypeSubRenderer(Renderer):
     lookup = {
             "param" : "Parameters",
             "exception" : "Exceptions",
-            "templateparam" : "Templates",
+            "templateparam" : "Template Parameters",
             "retval" : "Return Value",
             }
 


### PR DESCRIPTION
At least for my documentation, this feels like a better reflection of the meaning.