### PR TITLE
Uniquify function matches before argument processing

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -228,15 +228,25 @@ class DoxygenFunctionDirective(BaseDirective):
         if not matches:
             raise NoMatchingFunctionError()
 
-        if len(matches) == 1:
-            return matches[0]
+        # We can have multiple matches of the same signature such as finding it in a file's xml and
+        # a group's xml. In order to prevent false negatives on our match test we get a list of
+        # unique matches based on their ids from doxygen
+        unique_ids = set()
+        unique_matches = []
+        for node_stack in matches:
+            if node_stack[0].id not in unique_ids:
+                unique_ids.add(node_stack[0].id)
+                unique_matches.append(node_stack)
+
+        if len(unique_matches) == 1:
+            return unique_matches[0]
 
         node_stack = None
 
         signatures = []
 
         # Iterate over the potential matches
-        for entry in matches:
+        for entry in unique_matches:
 
             text_options = {'no-link': u'', 'outline': u''}
 


### PR DESCRIPTION
A potential fix for #194.

From the commit message:

> We've had an issue where the same function can appear multiple times in
our matches because it might be found in the xml output for a file and
for a group. This confuses our previous code as we're conclude we had
multiple matches and then expect to sort them based on their arguments
but their arguments would be the same and the user wouldn't think to
specify them because they know there is only one function with that name
in their code base.

> To counter this we uniquify the list of functions using the 'id'
provided by doxygen which is the same for the same function in different
places and then proceed as before.

> I wish there was a cleaner way to make a unique list based on an
attribute but I can't think of a better one.

@vitaut, I've just written this and it outlines the problem (we're matching the same function from where it appears in a file's xml output and a group's xml output and that confuses our matching code.) But I think maybe instead of this approach we should just skip groups whilst looking? We should be able to do that I think. I assume the function is always going to turn up in a file's xml output as there is always file output but there might not always be a group as well.

Thoughts?

Michael