### PR TITLE
Extend function filter to ignore groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ dev-test:
 	cd tests && PYTHONPATH=../:$(PTYONPATH) nosetests
 
 flake8:
-	flake8 breathe/*.py
+	flake8 breathe/*.py breathe/renderer/rst/doxygen/filter.py

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -121,8 +121,7 @@ class DoxygenFunctionDirective(BaseDirective):
         # Extract arguments from the function name.
         args = self.parse_args(args)
 
-        finder_filter = self.filter_factory.create_member_finder_filter(
-            namespace, function_name, 'function')
+        finder_filter = self.filter_factory.create_function_finder_filter(namespace, function_name)
 
         matches = []
         finder.filter_(finder_filter, matches)

--- a/breathe/renderer/rst/doxygen/filter.py
+++ b/breathe/renderer/rst/doxygen/filter.py
@@ -1083,6 +1083,18 @@ class FilterFactory(object):
             return (parent_is_compound & parent_is_file & node_matches) \
                 | (parent_is_compound & parent_is_not_file & node_matches)
 
+    def create_function_finder_filter(self, namespace, name):
+
+        parent = Parent()
+        parent_is_compound = parent.node_type == 'compound'
+        parent_is_group = parent.kind == 'group'
+
+        function_filter = self.create_member_finder_filter(namespace, name, 'function')
+        # Get matching functions but only ones in which the parent is either not a compound or if it
+        # is a compound it isn't a group. We want to skip function entries in groups as we'll find
+        # the same functions in a file's xml output elsewhere
+        return function_filter & (~parent_is_compound | ~parent_is_group)
+
     def create_enumvalue_finder_filter(self, name):
         """Returns a filter which looks for an enumvalue with the specified name."""
 

--- a/breathe/renderer/rst/doxygen/filter.py
+++ b/breathe/renderer/rst/doxygen/filter.py
@@ -199,6 +199,8 @@ We have to write:
 
 """
 
+import six
+
 
 class UnrecognisedKindError(Exception):
     pass
@@ -312,7 +314,7 @@ class NodeTypeAccessor(Accessor):
 
             # Horrible hack to silence errors on filtering unicode objects
             # until we fix the parsing
-            if type(data_object) == unicode:
+            if type(data_object) == six.text_type:
                 return "unicode"
             else:
                 raise e

--- a/breathe/renderer/rst/doxygen/filter.py
+++ b/breathe/renderer/rst/doxygen/filter.py
@@ -1090,10 +1090,10 @@ class FilterFactory(object):
         parent_is_group = parent.kind == 'group'
 
         function_filter = self.create_member_finder_filter(namespace, name, 'function')
-        # Get matching functions but only ones in which the parent is either not a compound or if it
-        # is a compound it isn't a group. We want to skip function entries in groups as we'll find
-        # the same functions in a file's xml output elsewhere
-        return function_filter & (~parent_is_compound | ~parent_is_group)
+        # Get matching functions but only ones where the parent is not a group. We want to skip
+        # function entries in groups as we'll find the same functions in a file's xml output
+        # elsewhere and having more than one match is confusing for our logic later on.
+        return function_filter & ~(parent_is_compound & parent_is_group)
 
     def create_enumvalue_finder_filter(self, name):
         """Returns a filter which looks for an enumvalue with the specified name."""

--- a/breathe/renderer/rst/doxygen/filter.py
+++ b/breathe/renderer/rst/doxygen/filter.py
@@ -399,7 +399,7 @@ class EndsWithFilter(Filter):
         self.options = options
 
     def allow(self, node_stack):
-        string = self.accessor(node_stack) 
+        string = self.accessor(node_stack)
         for entry in self.options:
             if string.endswith(entry):
                 return True
@@ -597,13 +597,13 @@ class FilterFactory(object):
 
     # C++ style public entries
     public_kinds = set([
-            "public-type",
-            "public-func",
-            "public-attrib",
-            "public-slot",
-            "public-static-func",
-            "public-static-attrib",
-            ])
+        "public-type",
+        "public-func",
+        "public-attrib",
+        "public-slot",
+        "public-static-func",
+        "public-static-attrib",
+    ])
 
     def __init__(self, globber_factory, path_handler):
 
@@ -630,7 +630,6 @@ class FilterFactory(object):
             filter_options['members'] = u''
 
         node = Node()
-        parent = Parent()
         grandparent = Ancestor(2)
         has_grandparent = HasAncestorFilter(2)
 
@@ -641,11 +640,7 @@ class FilterFactory(object):
             & (grandparent.kind != 'struct') \
             & (node.node_type == 'memberdef')
 
-        node_is_public = node.prot == 'public'
-
-        non_class_public_memberdefs = non_class_memberdef & node_is_public | ~ non_class_memberdef
-
-        return ( self.create_class_member_filter(filter_options) | non_class_memberdef ) \
+        return (self.create_class_member_filter(filter_options) | non_class_memberdef) \
             & self.create_innerclass_filter(filter_options) \
             & self.create_outline_filter(filter_options)
 
@@ -711,11 +706,10 @@ class FilterFactory(object):
 
                 # Accept any nodes which don't have a "sectiondef" as a parent or, if they do, only
                 # accept them if their names are in the members list
-                public_innerclass_filter = ~ node_is_innerclass_in_class | node_valueOf_is_in_members
+                public_innerclass_filter = ~node_is_innerclass_in_class | node_valueOf_is_in_members
 
             else:
                 allowed.add('public')
-
 
         node_is_in_allowed_scope = node.prot.is_one_of(allowed)
 
@@ -878,7 +872,7 @@ class FilterFactory(object):
         undoc_members = self._create_undoc_members_filter(options)
 
         # Allow any public/private members which also fit the undoc filter and all the descriptions
-        allowed_members = ( public_members | protected_members | private_members ) & undoc_members
+        allowed_members = (public_members | protected_members | private_members) & undoc_members
         return allowed_members | description
 
     def create_outline_filter(self, options):
@@ -1070,13 +1064,13 @@ class FilterFactory(object):
         parent = Parent()
 
         node_matches = (node.node_type == 'member') \
-                & (node.kind == kind) \
-                & (node.name == name)
+            & (node.kind == kind) \
+            & (node.name == name)
 
         if namespace:
             parent_matches = (parent.node_type == 'compound') \
-                    & ((parent.kind == 'namespace') | (parent.kind == 'class')) \
-                    & (parent.name == namespace)
+                & ((parent.kind == 'namespace') | (parent.kind == 'class')) \
+                & (parent.name == namespace)
 
             return parent_matches & node_matches
 
@@ -1099,7 +1093,7 @@ class FilterFactory(object):
         """Returns a filter which looks for a compound with the specified name and kind."""
 
         node = Node()
-        return (node.node_type == 'compound') & (node.kind == kind)  & (node.name == name)
+        return (node.node_type == 'compound') & (node.kind == kind) & (node.name == name)
 
     def create_finder_filter(self, kind, name):
         """Returns a filter which looks for the compound node from the index which is a group node
@@ -1135,4 +1129,3 @@ class FilterFactory(object):
 
         self.implementation_filename_extensions = \
             app.config.breathe_implementation_filename_extensions
-

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,3 +3,4 @@ Jinja2==2.7.3
 MarkupSafe==0.23
 Pygments==1.6
 Sphinx==1.2.2
+six==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
 render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=1.0.7', 'docutils>=0.5']
+requires = ['Sphinx>=1.0.7', 'docutils>=0.5', 'six>=1.4']
 
 if sys.version_info < (2, 4):
     print('ERROR: Sphinx requires at least Python 2.4 to run.')


### PR DESCRIPTION
A potential solution for #194.

From the commit message:

> We take a standard 'function' type member filter and then extend it by
saying we're only interested in results in which the parent is either
not a compound or if it is a compound then it isn't a group. ie. we
want to skip functions in groups as they are going to appear in a file's
xml output as well and having them match twice confuses our handling of
them later on.

@vitaut, this is the alternative approach. I think it is probably better. Treats the cause rather than the symptom. Any thoughts?

There are some flake8 fixes in there too.

Cheers,
Michael