### PR TITLE
Add templated struct function failing example

### DIFF
--- a/documentation/source/members.rst
+++ b/documentation/source/members.rst
@@ -19,7 +19,6 @@ Specific Members
    :members: functionS, anotherFunction
    :no-link:
 
-
 No Members
 ----------
 
@@ -27,3 +26,17 @@ No Members
    :path: ../../examples/specific/members/xml
    :no-link:
 
+Struct Members
+----------------
+
+.. doxygenfunction:: testnamespace::MyClass::MyClass
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:
+
+.. doxygenfunction:: testnamespace::MyClass<T>::MyClass
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:
+
+.. doxygenfunction:: testnamespace::MyClass< T >::MyClass
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -20,8 +20,9 @@ HAVE_DOT  = /usr/bin/dot
 
 projects  = nutshell alias rst inline namespacefile c_file array c_enum \
 			members userdefined fixedwidthfont latexmath functionOverload \
-			image name union group struct qtslots lists headings links parameters \
-			template_class template_class_non_type template_function template_specialisation enum
+			image name union group struct struct_function qtslots lists \
+			headings links parameters template_class template_class_non_type \
+			template_function template_specialisation enum
 
 special   = programlisting decl_impl multifilexml auto class typedef
 

--- a/examples/specific/struct_function.cfg
+++ b/examples/specific/struct_function.cfg
@@ -1,0 +1,11 @@
+PROJECT_NAME     = "Struct Function Command"
+OUTPUT_DIRECTORY = struct_function
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = struct_function.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES

--- a/examples/specific/struct_function.h
+++ b/examples/specific/struct_function.h
@@ -1,0 +1,16 @@
+
+namespace testnamespace {
+
+//! \brief templated struct with functions
+template <typename T>
+struct MyClass
+{
+    //! \brief struct empty constructor
+    MyClass();
+
+    //! \brief struct copy constructor
+    MyClass(const MyClass&);
+};
+
+}
+


### PR DESCRIPTION
This commit is linked to issue #219
Add a failing example with functions in a templated struct

Signed-off-by: Guillaume Delbergue <guillaume.delbergue@greensocs.com>