### PR TITLE
Use 'default project' as the default name for project info

### DIFF
--- a/breathe/project.py
+++ b/breathe/project.py
@@ -205,7 +205,7 @@ class ProjectInfoFactory(object):
 
     def create_project_info(self, options):
 
-        name = ""
+        name = self.default_project
 
         if "project" in options:
             try:


### PR DESCRIPTION
Without this change a lot if internal references to the default project will be created as project0linktothing, which is a bit ugly. Instead by defaulting 'name' to default project it will become default_projectlinktothing, which then matches what you would get if you would have actually specified the project.