### PR TITLE
Quick fix for the duplicate ID issue

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -65,7 +65,7 @@ class BaseDirective(rst.Directive):
         renderer_factory_creator = self.renderer_factory_creator_constructor.create_factory_creator(
             project_info,
             self.state.document,
-            options,
+            options,  # not used in the call
             target_handler
             )
 
@@ -83,6 +83,9 @@ class BaseDirective(rst.Directive):
         except FileIOError as e:
             return format_parser_error("doxygenclass", e.error, e.filename, self.state, self.lineno)
 
-        context = RenderContext(node_stack, mask_factory, self.directive_args)
+        # Quick hack to get it working: inject options here
+        directive_args = self.directive_args[:]
+        directive_args[2] = options
+        context = RenderContext(node_stack, mask_factory, directive_args)
         object_renderer = renderer_factory.create_renderer(context)
         return object_renderer.render()

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -237,7 +237,7 @@ class DoxygenFunctionDirective(BaseDirective):
         # Iterate over the potential matches
         for entry in matches:
 
-            text_options = {'no-link': u'', 'outline': u''}
+            text_options = {'no-link': u'', 'outline': u''}  # this is never used
 
             # Render the matches to docutils nodes
             target_handler = self.target_handler_factory.create_target_handler(

--- a/breathe/renderer/rst/doxygen/__init__.py
+++ b/breathe/renderer/rst/doxygen/__init__.py
@@ -351,6 +351,7 @@ class DoxygenToRstRendererFactoryCreatorConstructor(object):
 
     def create_factory_creator(self, project_info, document, options, target_handler):
 
+        # the argument `options` is never used
         return DoxygenToRstRendererFactoryCreator(
                 self.node_factory,
                 self.parser_factory,


### PR DESCRIPTION
This change suggested by @dean0x7d fixes ``SEVERE: Duplicate ID`` warnings and missing anchors in case of overloads. Here's an example that reproduces the problem (requires Sphinx version https://github.com/sphinx-doc/sphinx/commit/1021f4cdd71d2bb484b37c9b0acb87150c39aaa7)

```c++
/** Test */
char operator"" _format(const char *s, std::size_t);

wchar_t operator"" _format(const wchar_t *s, std::size_t);
```
but I guess the same may apply to other overloads.

Here are some more details: https://github.com/cppformat/cppformat/pull/207#issuecomment-149341656.

I'm not sure what's the best solution here. @michaeljones, do you think options should be passed to `renderer_factory_creator_constructor.create_factory_creator` at all?