### PR TITLE
support Sphinx's `needs_extensions` config option

### DIFF
--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -14,3 +14,4 @@ def setup(app):
     from . import directives
 
     directives.setup(app)
+    return {'version': __version__}


### PR DESCRIPTION
The `setup()` function can [return a dictionary](http://www.sphinx-doc.org/en/stable/extdev/index.html#extension-metadata) of values, so I added its version to allow the new `needs_extensions` config value to work.