### PR TITLE
Add support for extra signature nodes used by Sphinx for templates

### DIFF
--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -332,10 +332,14 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
         nodes = self.run_domain_directive(self.data_object.kind, self.context.directive_args[1])
         node = nodes[1]
-        signode, contentnode = node.children
-        signode.insert(0, self.create_doxygen_target())
-        self.update_signature(signode)
-        contentnode.extend(self.description())
+        # Templates have multiple signature nodes in recent versions of Sphinx.
+        # Insert Doxygen target into the first signature node.
+        node.children[0].insert(0, self.create_doxygen_target())
+        # Update the last signature node because it contains the actual signature
+        # rather than "template <...>".
+        self.update_signature(node.children[-2])
+        # Add description to the content node.
+        node.children[-1].extend(self.description())
 
         template_node = self.create_template_node(self.data_object)
         if template_node:


### PR DESCRIPTION
This PR adds support for multiple signature nodes used by recent versions of Sphinx for templates. Without it processing templates gives an exception (https://github.com/ampl/mp/issues/91#issuecomment-193527230):

```
...
  File "doc/build/virtualenv/local/lib/python2.7/site-packages/breathe/renderer/compound.py", line 21, in renderIterable
    output.extend(child_renderer.render())
  File "doc/build/virtualenv/local/lib/python2.7/site-packages/breathe/renderer/compound.py", line 335, in render
    signode, contentnode = node.children
ValueError: too many values to unpack
```