### PR TITLE
apidoc: avoid unnecessarily updating timestamp of generated files

### DIFF
--- a/breathe/apidoc.py
+++ b/breathe/apidoc.py
@@ -52,6 +52,14 @@ def write_file(name, text, args):
             except OSError as exc:  # Guard against race condition
                 if exc.errno != errno.EEXIST:
                     raise
+        target = open(fname, 'r')
+        try:
+            orig = target.read()
+        finally:
+            target.close()
+        if orig == text:
+            print('File %s up to date, skipping.' % fname)
+            return
         target = open(fname, 'w')
         try:
             target.write(text)


### PR DESCRIPTION
Efficiently rebuild