### PR TITLE
Pass function CV-qualifiers to Sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
 language: python
 
 env:
-  - SPHINX_VERSION=1.2.3 TRAVIS_CI=True
-  - SPHINX_VERSION=1.3.1 TRAVIS_CI=True
+  - SPHINX_VERSION=1.4 TRAVIS_CI=True
 
 python:
   - "2.6"

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Development is currently done with:
  
 - Python 2.7.4
 - Docutils 0.11
-- Sphinx 1.2.2
+- Sphinx 1.4
 - Doxygen 1.8.4
 
 Doxygen 1.5.1 seems to produce xml with repeated sections which causes Breathe

--- a/breathe/renderer/__init__.py
+++ b/breathe/renderer/__init__.py
@@ -254,7 +254,7 @@ class DoxygenToRstRendererFactoryCreator(object):
             "docsect1": compoundrenderer.DocSect1TypeSubRenderer,
             "docsimplesect": compoundrenderer.DocSimpleSectTypeSubRenderer,
             "doctitle": compoundrenderer.DocTitleTypeSubRenderer,
-            "docformula": compoundrenderer.DocForumlaTypeSubRenderer,
+            "docformula": compoundrenderer.DocFormulaTypeSubRenderer,
             "docimage": compoundrenderer.DocImageTypeSubRenderer,
             "docurllink": compoundrenderer.DocURLLinkSubRenderer,
             "listing": compoundrenderer.ListingTypeSubRenderer,

--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -1,6 +1,6 @@
 
 from .base import Renderer
-from .index import CompoundRenderer
+from .index import CompoundRenderer, NodeFinder
 import re
 import six
 
@@ -338,14 +338,14 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
         nodes = self.run_domain_directive(self.data_object.kind, self.context.directive_args[1])
         node = nodes[1]
+        finder = NodeFinder(node.document)
+        node.walk(finder)
+
         # Templates have multiple signature nodes in recent versions of Sphinx.
         # Insert Doxygen target into the first signature node.
         node.children[0].insert(0, self.create_doxygen_target())
-        # Update the last signature node because it contains the actual signature
-        # rather than "template <...>".
-        self.update_signature(node.children[-2])
-        # Add description to the content node.
-        node.children[-1].extend(self.description())
+        self.update_signature(finder.declarator)
+        finder.content.extend(self.description())
 
         template_node = self.create_template_node(self.data_object)
         if template_node:

--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -721,7 +721,7 @@ class DocTitleTypeSubRenderer(Renderer):
         return renderIterable(self, self.data_object.content_)
 
 
-class DocForumlaTypeSubRenderer(Renderer):
+class DocFormulaTypeSubRenderer(Renderer):
 
     def render(self):
 

--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -307,16 +307,6 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         if self.data_object.virt != 'non-virtual':
             signode.insert(0, self.node_factory.Text('virtual '))
 
-        # Add CV-qualifiers
-        if self.data_object.const == 'yes':
-            signode.append(self.node_factory.Text(' const'))
-        # The doxygen xml output doesn't seem to properly register 'volatile' as the xml attribute
-        # 'volatile' so we have to check the argsstring for the moment. Maybe it'll change in
-        # doxygen at some point. Registered as bug:
-        #     https://bugzilla.gnome.org/show_bug.cgi?id=733451
-        if self.data_object.volatile == 'yes' or self.data_object.argsstring.endswith('volatile'):
-            signode.append(self.node_factory.Text(' volatile'))
-
         # Add `= 0` for pure virtual members.
         if self.data_object.virt == 'pure-virtual':
             signode.append(self.node_factory.Text(' = 0'))
@@ -334,6 +324,16 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         virtual = 'virtual '
         if signature.startswith(virtual):
             signature = signature[len(virtual):]
+        
+        # Add CV-qualifiers.
+        if self.data_object.const == 'yes':
+            signature += ' const'
+        # The doxygen xml output doesn't register 'volatile' as the xml attribute for functions
+        # until version 1.8.8 so we also check argsstring:
+        #     https://bugzilla.gnome.org/show_bug.cgi?id=733451
+        if self.data_object.volatile == 'yes' or self.data_object.argsstring.endswith('volatile'):
+            signature += ' volatile'
+
         self.context.directive_args[1] = [signature]
 
         nodes = self.run_domain_directive(self.data_object.kind, self.context.directive_args[1])

--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -324,7 +324,7 @@ class FuncMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
         virtual = 'virtual '
         if signature.startswith(virtual):
             signature = signature[len(virtual):]
-        
+
         # Add CV-qualifiers.
         if self.data_object.const == 'yes':
             signature += ' const'

--- a/breathe/renderer/index.py
+++ b/breathe/renderer/index.py
@@ -40,7 +40,12 @@ class CompoundRenderer(Renderer):
         self.context.directive_args[1] = [self.get_fully_qualified_name()]
         nodes = self.run_domain_directive(kind, self.context.directive_args[1])
         node = nodes[1]
-        signode, contentnode = node.children
+
+        # Templates have multiple signature nodes in recent versions of Sphinx.
+        # Update the last signature node because it contains the actual signature
+        # rather than "template <...>".
+        signode = node.children[-2]
+        contentnode = node.children[-1]
 
         # The cpp domain in Sphinx doesn't support structs at the moment, so change the text from "class "
         # to the correct kind which can be "class " or "struct ".

--- a/breathe/renderer/index.py
+++ b/breathe/renderer/index.py
@@ -1,5 +1,7 @@
 
+from docutils import nodes
 from .base import Renderer
+
 
 class DoxygenTypeSubRenderer(Renderer):
 
@@ -14,6 +16,24 @@ class DoxygenTypeSubRenderer(Renderer):
             nodelist.extend(compound_renderer.render())
 
         return nodelist
+
+
+class NodeFinder(nodes.SparseNodeVisitor):
+    """Find the Docutils desc_signature declarator and desc_content nodes."""
+
+    def __init__(self, document):
+        nodes.SparseNodeVisitor.__init__(self, document)
+        self.declarator = None
+        self.content = None
+
+    def visit_desc_signature(self, node):
+        # Find the last signature node because it contains the actual declarator
+        # rather than "template <...>". In Sphinx 1.4.1 we'll be able to use sphinx_cpp_tagname:
+        # https://github.com/michaeljones/breathe/issues/242
+        self.declarator = node
+
+    def visit_desc_content(self, node):
+        self.content = node
 
 
 class CompoundRenderer(Renderer):
@@ -41,22 +61,19 @@ class CompoundRenderer(Renderer):
         nodes = self.run_domain_directive(kind, self.context.directive_args[1])
         node = nodes[1]
 
-        # Templates have multiple signature nodes in recent versions of Sphinx.
-        # Update the last signature node because it contains the actual signature
-        # rather than "template <...>".
-        signode = node.children[-2]
-        contentnode = node.children[-1]
+        finder = NodeFinder(node.document)
+        node.walk(finder)
 
         # The cpp domain in Sphinx doesn't support structs at the moment, so change the text from "class "
         # to the correct kind which can be "class " or "struct ".
-        signode[0] = self.node_factory.desc_annotation(kind + ' ', kind + ' ')
+        finder.declarator[0] = self.node_factory.desc_annotation(kind + ' ', kind + ' ')
 
         # Check if there is template information and format it as desired
         template_signode = self.create_template_node(file_data.compounddef)
         if template_signode:
             node.insert(0, template_signode)
         node.children[0].insert(0, doxygen_target)
-        return nodes, contentnode
+        return nodes, finder.content
 
     def render(self):
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils==0.12
 Jinja2==2.7.3
 MarkupSafe==0.23
 Pygments==1.6
-Sphinx==1.2.2
+Sphinx==1.4
 six==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
 render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=1.0.7', 'docutils>=0.5', 'six>=1.4']
+requires = ['Sphinx>=1.4', 'docutils>=0.5', 'six>=1.4']
 
 if sys.version_info < (2, 4):
     print('ERROR: Sphinx requires at least Python 2.4 to run.')

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,7 +1,8 @@
 # Renderer tests
 
 import sphinx.environment
-from breathe.renderer.compound import FuncMemberDefTypeSubRenderer
+from breathe.parser.compound import linkedTextTypeSub, memberdefTypeSub, paramTypeSub, MixedContainer
+from breathe.renderer.compound import FuncMemberDefTypeSubRenderer, TypedefMemberDefTypeSubRenderer
 from docutils import frontend, nodes, parsers, utils
 from sphinx.domains import CPPDomain
 from distutils.version import LooseVersion
@@ -10,31 +11,50 @@ from distutils.version import LooseVersion
 sphinx.locale.init([], None)
 
 
-class MockDoxygenNode:
+class TestDoxygenNode:
+    """
+    A base class for test wrappers of Doxygen nodes. It allows setting all attributes via keyword arguments
+    in the constructor.
+    """
+    def __init__(self, cls, **kwargs):
+        if cls:
+            cls.__init__(self)
+        for name, value in kwargs.items():
+            if not hasattr(self, name):
+                raise AttributeError('invalid attribute ' + name)
+            setattr(self, name, value)
+
+
+class TestMixedContainer(MixedContainer, TestDoxygenNode):
+    """A test wrapper of Doxygen mixed container."""
     def __init__(self, **kwargs):
-        attributes = {
-            'id': None,
-            'kind': None,
-            'name': '',
-            'definition': '',
-            'param': [],
-            'virt': None,
-            'const': None,
-            'volatile': None,
-            'argsstring': '',
-            'briefdescription': None,
-            'detaileddescription': None,
-            'templateparamlist': None
-        }
-        for name, value in attributes.items():
-            setattr(self, name, kwargs.get(name, value))
+        MixedContainer.__init__(self, None, None, None, None)
+        TestDoxygenNode.__init__(self, None, **kwargs)
+
+
+class TestLinkedText(linkedTextTypeSub, TestDoxygenNode):
+    """A test wrapper of Doxygen linked text."""
+    def __init__(self, **kwargs):
+        TestDoxygenNode.__init__(self, linkedTextTypeSub, **kwargs)
+
+
+class TestMemberDef(memberdefTypeSub, TestDoxygenNode):
+    """A test wrapper of Doxygen class/file/namespace member symbol such as a function declaration."""
+    def __init__(self, **kwargs):
+        TestDoxygenNode.__init__(self, memberdefTypeSub, **kwargs)
+
+
+class TestParam(paramTypeSub, TestDoxygenNode):
+    """A test wrapper of Doxygen parameter."""
+    def __init__(self, **kwargs):
+        TestDoxygenNode.__init__(self, paramTypeSub, **kwargs)
 
 
 class MockState:
     def __init__(self):
         env = sphinx.environment.BuildEnvironment(None, None, None)
         CPPDomain(env)
-        env.temp_data['docname'] = None
+        env.temp_data['docname'] = 'mock-doc'
         settings = frontend.OptionParser(
             components=(parsers.rst.Parser,)).get_default_values()
         settings.env = env
@@ -60,6 +80,14 @@ class MockStateMachine:
         self.reporter = MockReporter()
 
 
+class MockMaskFactory:
+    def __init__(self):
+        pass
+
+    def mask(self, node):
+        return node
+
+
 class MockContext:
     def __init__(self, node_stack):
         self.domain = None
@@ -74,6 +102,7 @@ class MockContext:
             None,  # block_text
             MockState(), MockStateMachine()]
         self.child = None
+        self.mask_factory = MockMaskFactory()
 
     def create_child_context(self, attribute):
         return self
@@ -92,14 +121,6 @@ class MockTargetHandler:
         pass
 
     def create_target(self, refid):
-        pass
-
-
-class MockNodeFactory:
-    def __init__(self):
-        pass
-
-    def Text(self, data):
         pass
 
 
@@ -180,15 +201,31 @@ def test_find_node():
                     'the number of nodes Text is 2')
 
 
+def render(member_def, renderer_class):
+    """Render Doxygen *member_def* with *renderer_class*."""
+    renderer = renderer_class(MockProjectInfo(), MockContext([member_def]),
+                              None,  # renderer_factory
+                              sphinx.addnodes,
+                              None,  # state
+                              None,  # document
+                              MockTargetHandler())
+    return renderer.render()
+
+
 def test_func_renderer():
-    doxy_node = MockDoxygenNode(definition='void f', argsstring='()')
-    renderer = FuncMemberDefTypeSubRenderer(MockProjectInfo(), MockContext([doxy_node]),
-                                            None,  # renderer_factory
-                                            MockNodeFactory(),
-                                            None,  # state
-                                            None,  # document
-                                            MockTargetHandler())
-    nodes = renderer.render()
-    node = find_node(nodes, 'desc_name')
+    member_def = TestMemberDef(definition='void foo', argsstring='(int)', virt='non-virtual',
+                               param=[TestParam(type_=TestLinkedText(content_=[TestMixedContainer(value=u'int')]))])
+    signature = find_node(render(member_def, FuncMemberDefTypeSubRenderer), 'desc_signature')
+    assert signature[0] == 'void'
     if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
-        assert node[0] == 'f'
+        assert find_node(signature, 'desc_name')[0] == 'foo'
+        params = find_node(signature, 'desc_parameterlist')
+        assert len(params) == 1
+        param = params[0]
+        assert param[0] == 'int'
+
+
+def test_typedef_renderer():
+    member_def = TestMemberDef(kind='typedef', definition='typedef int foo')
+    signature = find_node(render(member_def, TypedefMemberDefTypeSubRenderer), 'desc_signature')
+    assert signature.astext() == 'typedef int foo'

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -6,7 +6,6 @@ from breathe.parser.compound import linkedTextTypeSub, memberdefTypeSub, paramTy
 from breathe.renderer.compound import FuncMemberDefTypeSubRenderer, TypedefMemberDefTypeSubRenderer
 from docutils import frontend, nodes, parsers, utils
 from sphinx.domains import CPPDomain
-from distutils.version import LooseVersion
 
 
 sphinx.locale.init([], None)
@@ -218,12 +217,11 @@ def test_render_func():
                                param=[TestParam(type_=TestLinkedText(content_=[TestMixedContainer(value=u'int')]))])
     signature = find_node(render(member_def, FuncMemberDefTypeSubRenderer), 'desc_signature')
     assert signature[0] == 'void'
-    if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
-        assert find_node(signature, 'desc_name')[0] == 'foo'
-        params = find_node(signature, 'desc_parameterlist')
-        assert len(params) == 1
-        param = params[0]
-        assert param[0] == 'int'
+    assert find_node(signature, 'desc_name')[0] == 'foo'
+    params = find_node(signature, 'desc_parameterlist')
+    assert len(params) == 1
+    param = params[0]
+    assert param[0] == 'int'
 
 
 def test_render_typedef():

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,6 +1,7 @@
 # Renderer tests
 
 import sphinx.environment
+from breathe.node_factory import create_node_factory
 from breathe.parser.compound import linkedTextTypeSub, memberdefTypeSub, paramTypeSub, MixedContainer
 from breathe.renderer.compound import FuncMemberDefTypeSubRenderer, TypedefMemberDefTypeSubRenderer
 from docutils import frontend, nodes, parsers, utils
@@ -205,14 +206,14 @@ def render(member_def, renderer_class):
     """Render Doxygen *member_def* with *renderer_class*."""
     renderer = renderer_class(MockProjectInfo(), MockContext([member_def]),
                               None,  # renderer_factory
-                              sphinx.addnodes,
+                              create_node_factory(),
                               None,  # state
                               None,  # document
                               MockTargetHandler())
     return renderer.render()
 
 
-def test_func_renderer():
+def test_render_func():
     member_def = TestMemberDef(definition='void foo', argsstring='(int)', virt='non-virtual',
                                param=[TestParam(type_=TestLinkedText(content_=[TestMixedContainer(value=u'int')]))])
     signature = find_node(render(member_def, FuncMemberDefTypeSubRenderer), 'desc_signature')
@@ -225,7 +226,14 @@ def test_func_renderer():
         assert param[0] == 'int'
 
 
-def test_typedef_renderer():
+def test_render_typedef():
     member_def = TestMemberDef(kind='typedef', definition='typedef int foo')
     signature = find_node(render(member_def, TypedefMemberDefTypeSubRenderer), 'desc_signature')
     assert signature.astext() == 'typedef int foo'
+
+
+def test_render_const_func():
+    member_def = TestMemberDef(kind='function', definition='void f', argsstring='() const',
+                               virt='non-virtual', const='yes')
+    signature = find_node(render(member_def, FuncMemberDefTypeSubRenderer), 'desc_signature')
+    assert '_CPPv2NK1fEv' in signature['ids']


### PR DESCRIPTION
This PR fixes #246 by changing the way function CV-qualifiers are handled. Instead of adding them to the rendered Sphinx nodes, they are added to a function signature which is passed to the Sphinx cpp domain. This way proper IDs are generated which is tested using the new test infrastructure (yay!)

This won't work with Sphinx 1.3 or older, so I changed the required version to 1.4 as discussed in #243.