### PR TITLE
Replace "typedef" with "using" when rendering type aliases (#213)

### DIFF
--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -403,15 +403,24 @@ class EnumMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
 class TypedefMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):
 
-    def declaration(self):
-        decl = get_definition_without_template_args(self.data_object)
+    def __init__(self, *args):
+        MemberDefTypeSubRenderer.__init__(self, *args)
+        self.decl = get_definition_without_template_args(self.data_object)
         typedef = "typedef "
         usingalias = "using "
-        if decl.startswith(typedef):
-            decl = decl[len(typedef):]
-        elif decl.startswith(usingalias):
-            decl = decl[len(usingalias):]
-        return decl
+        self.kind = self.data_object.kind
+        if self.decl.startswith(typedef):
+            self.decl = self.decl[len(typedef):]
+        elif self.decl.startswith(usingalias):
+            self.decl = self.decl[len(usingalias):]
+            self.kind = "using"
+
+    def objtype(self):
+        """Return the type of the rendered object."""
+        return self.kind
+
+    def declaration(self):
+        return self.decl
 
 
 class VariableMemberDefTypeSubRenderer(MemberDefTypeSubRenderer):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -230,6 +230,12 @@ def test_render_typedef():
     assert signature.astext() == 'typedef int foo'
 
 
+def test_render_using_alias():
+    member_def = TestMemberDef(kind='typedef', definition='using foo = int')
+    signature = find_node(render(member_def, TypedefMemberDefTypeSubRenderer), 'desc_signature')
+    assert signature.astext() == 'using foo = int'
+
+
 def test_render_const_func():
     member_def = TestMemberDef(kind='function', definition='void f', argsstring='() const',
                                virt='non-virtual', const='yes')


### PR DESCRIPTION
This PR fixes rendering of using type aliases such as

```c++
using foo = int;
```