### PR TITLE
Making directives.py Python 3.x compatible

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -769,7 +769,7 @@ class FileStateCache(object):
 
         stale = []
 
-        for filename, info in self.app.env.breathe_file_state.iteritems():
+        for filename, info in self.app.env.breathe_file_state.items():
             old_mtime, docnames = info
             if self.mtimer.get_mtime(filename) > old_mtime:
                 stale.extend(docnames)
@@ -783,7 +783,7 @@ class FileStateCache(object):
 
         toremove = []
 
-        for filename, info in self.app.env.breathe_file_state.iteritems():
+        for filename, info in self.app.env.breathe_file_state.items():
 
             _, docnames = info
             docnames.discard(docname)


### PR DESCRIPTION
Changing dictionary item iterations all to dict.items() makes the code
compatible with both Python 2.x and 3.x