### PR TITLE
Add programlisting nodes to content (#70)

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -1,5 +1,6 @@
 """
 Generated Mon Feb  9 19:08:05 2009 by generateDS.py.
+This file contains manual modifications.
 """
 
 from xml.dom import minidom
@@ -847,7 +848,10 @@ class docParaTypeSub(supermod.docParaType):
         elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == 'programlisting':
             obj_ = supermod.listingType.factory()
             obj_.build(child_)
-            self.programlisting.append(obj_)
+            # Add programlisting nodes to self.content rather than self.programlisting,
+            # because programlisting and content nodes can interleave as shown in
+            # https://www.stack.nl/~dimitri/doxygen/manual/examples/include/html/example.html.
+            self.content.append(obj_)
         elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == 'image':
             obj_ = supermod.docImageType.factory()
             obj_.build(child_)

--- a/breathe/renderer/compound.py
+++ b/breathe/renderer/compound.py
@@ -581,8 +581,6 @@ class DocParaTypeSubRenderer(Renderer):
     def render(self):
 
         nodelist = renderIterable(self, self.data_object.content)
-
-        nodelist.extend(renderIterable(self, self.data_object.programlisting))
         nodelist.extend(renderIterable(self, self.data_object.images))
 
         # Returns, user par's, etc


### PR DESCRIPTION
The programlisting nodes and content nodes can interleave so we need to place them in the same array. Here's an example from the Doxygen docs:

https://www.stack.nl/~dimitri/doxygen/manual/examples/include/html/example.html