### PR TITLE
Support for struct member functions

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -1,4 +1,6 @@
 
+from __future__ import unicode_literals
+
 from .finder.core import FinderFactory
 from .parser import DoxygenParserFactory
 from .renderer import DoxygenToRstRendererFactory
@@ -835,12 +837,12 @@ def setup(app):
             app.config.breathe_doxygen_config_options
         )
 
-    app.connect("builder-inited", doxygen_hook)
+    app.connect(b"builder-inited", doxygen_hook)
 
-    app.connect("builder-inited", directive_factory.get_config_values)
+    app.connect(b"builder-inited", directive_factory.get_config_values)
 
-    app.connect("builder-inited", filter_factory.get_config_values)
+    app.connect(b"builder-inited", filter_factory.get_config_values)
 
-    app.connect("env-get-outdated", file_state_cache.get_outdated)
+    app.connect(b"env-get-outdated", file_state_cache.get_outdated)
 
-    app.connect("env-purge-doc", file_state_cache.purge_doc)
+    app.connect(b"env-purge-doc", file_state_cache.purge_doc)

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -1,6 +1,4 @@
 
-from __future__ import unicode_literals
-
 from .finder.core import FinderFactory
 from .parser import DoxygenParserFactory
 from .renderer import DoxygenToRstRendererFactory
@@ -837,12 +835,12 @@ def setup(app):
             app.config.breathe_doxygen_config_options
         )
 
-    app.connect(b"builder-inited", doxygen_hook)
+    app.connect("builder-inited", doxygen_hook)
 
-    app.connect(b"builder-inited", directive_factory.get_config_values)
+    app.connect("builder-inited", directive_factory.get_config_values)
 
-    app.connect(b"builder-inited", filter_factory.get_config_values)
+    app.connect("builder-inited", filter_factory.get_config_values)
 
-    app.connect(b"env-get-outdated", file_state_cache.get_outdated)
+    app.connect("env-get-outdated", file_state_cache.get_outdated)
 
-    app.connect(b"env-purge-doc", file_state_cache.purge_doc)
+    app.connect("env-purge-doc", file_state_cache.purge_doc)

--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -1059,9 +1059,9 @@ class FilterFactory(object):
 
         if namespace:
             parent_matches = (parent.node_type == 'compound') \
-                & ((parent.kind == 'namespace')
-                   | (parent.kind == 'class')
-                   | (parent.kind == 'struct')) \
+                & ((parent.kind == 'namespace') |
+                   (parent.kind == 'class') |
+                   (parent.kind == 'struct')) \
                 & (parent.name == namespace)
 
             return parent_matches & node_matches

--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -1059,7 +1059,9 @@ class FilterFactory(object):
 
         if namespace:
             parent_matches = (parent.node_type == 'compound') \
-                & ((parent.kind == 'namespace') | (parent.kind == 'class')) \
+                & ((parent.kind == 'namespace')
+                   | (parent.kind == 'class')
+                   | (parent.kind == 'struct')) \
                 & (parent.name == namespace)
 
             return parent_matches & node_matches

--- a/documentation/source/members.rst
+++ b/documentation/source/members.rst
@@ -19,7 +19,6 @@ Specific Members
    :members: functionS, anotherFunction
    :no-link:
 
-
 No Members
 ----------
 
@@ -27,3 +26,17 @@ No Members
    :path: ../../examples/specific/members/xml
    :no-link:
 
+Struct Members
+----------------
+
+.. doxygenfunction:: testnamespace::MyClass::MyClass
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:
+
+.. doxygenfunction:: testnamespace::MyClass<T>::MyClass
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:
+
+.. doxygenfunction:: testnamespace::MyClass< T >::MyClass
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:

--- a/documentation/source/members.rst
+++ b/documentation/source/members.rst
@@ -33,3 +33,6 @@ Struct Members
    :path: ../../examples/specific/struct_function/xml
    :no-link:
 
+.. doxygenfunction:: testnamespace::MyClass::MyClass(const MyClass&)
+   :path: ../../examples/specific/struct_function/xml
+   :no-link:

--- a/documentation/source/members.rst
+++ b/documentation/source/members.rst
@@ -33,10 +33,3 @@ Struct Members
    :path: ../../examples/specific/struct_function/xml
    :no-link:
 
-.. doxygenfunction:: testnamespace::MyClass<T>::MyClass
-   :path: ../../examples/specific/struct_function/xml
-   :no-link:
-
-.. doxygenfunction:: testnamespace::MyClass< T >::MyClass
-   :path: ../../examples/specific/struct_function/xml
-   :no-link:

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -20,8 +20,9 @@ HAVE_DOT  = /usr/bin/dot
 
 projects  = nutshell alias rst inline namespacefile c_file array c_enum inheritance \
 			members userdefined fixedwidthfont latexmath functionOverload \
-			image name union group struct qtslots lists headings links parameters \
-			template_class template_class_non_type template_function template_specialisation enum
+			image name union group struct struct_function qtslots lists \
+			headings links parameters template_class template_class_non_type \
+			template_function template_specialisation enum
 
 special   = programlisting decl_impl multifilexml auto class typedef
 

--- a/examples/specific/struct_function.cfg
+++ b/examples/specific/struct_function.cfg
@@ -1,0 +1,11 @@
+PROJECT_NAME     = "Struct Function Command"
+OUTPUT_DIRECTORY = struct_function
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = struct_function.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES

--- a/examples/specific/struct_function.h
+++ b/examples/specific/struct_function.h
@@ -1,0 +1,16 @@
+
+namespace testnamespace {
+
+//! \brief templated struct with functions
+template <typename T>
+struct MyClass
+{
+    //! \brief struct empty constructor
+    MyClass();
+
+    //! \brief struct copy constructor
+    MyClass(const MyClass&);
+};
+
+}
+


### PR DESCRIPTION
This PR is based on the `struct-function` branch with two changes:

* Reverted "Switch file to unicode literals" commit because it caused failures on Python 3.
* Fixed flake8 errors "W503 line break before binary operator" on Travis.
