### PR TITLE
Use the cpp domain type directive for using declarations (#268)

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -17,6 +17,7 @@ class DomainDirectiveFactory(object):
         'slot': (cpp.CPPFunctionObject, 'function'),
         'enum': (cpp.CPPTypeObject, 'type'),
         'typedef': (cpp.CPPTypeObject, 'type'),
+        'using': (cpp.CPPTypeObject, 'type'),
         'union': (cpp.CPPTypeObject, 'type'),
         'namespace': (cpp.CPPTypeObject, 'type'),
         # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for


### PR DESCRIPTION
This little PR fixes handling of `using` declarations. Now they are correctly passed to the cpp type directive.