### PR TITLE
Fix for issue #200

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -597,7 +597,7 @@ class SphinxRenderer(object):
             definition_list = self.node_factory.definition_list("", *definition_nodes)
             nodelist.append(definition_list)
 
-        return [self.node_factory.inline("", "", *nodelist)]
+        return [self.node_factory.inline(" ", " ", *nodelist)]
 
     def visit_docimage(self, node):
         """Output docutils image node using name attribute from xml as the uri"""

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -597,7 +597,7 @@ class SphinxRenderer(object):
             definition_list = self.node_factory.definition_list("", *definition_nodes)
             nodelist.append(definition_list)
 
-        return [self.node_factory.paragraph("", "", *nodelist)]
+        return [self.node_factory.inline("", "", *nodelist)]
 
     def visit_docimage(self, node):
         """Output docutils image node using name attribute from xml as the uri"""
@@ -1041,7 +1041,7 @@ class SphinxRenderer(object):
 
         term = self.node_factory.literal("", "", *nodelist)
 
-        separator = self.node_factory.Text(" - ")
+        separator = self.node_factory.Text(" : ")
 
         nodelist = self.render_optional(node.parameterdescription)
 


### PR DESCRIPTION
Doxygen's parameter descriptions are now rendered as inline text instead of as a new paragraph.
