### PR TITLE
Fix for #271

### DIFF
--- a/breathe/process.py
+++ b/breathe/process.py
@@ -84,6 +84,6 @@ class AutoDoxygenProcessHandle(object):
 
         self.write_file(build_dir, cfgfile, cfg)
 
-        self.run_process(['doxygen', cfgfile], cwd=build_dir)
+        self.run_process(['doxygen', cfgfile], cwd=build_dir, shell=True)
 
         return self.path_handler.join(build_dir, name, "xml")


### PR DESCRIPTION
Windows requires the shell true option for the path to work.