### PR TITLE
Fix for #275 - Shell for auto-doxygen subprocess 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.6"
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - SPHINX_VERSION=1.4 TRAVIS_CI=True
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -28,4 +27,3 @@ script:
   - make DOXYGEN=doxygen DEBUG=""
   - make test
   - make flake8
-

--- a/breathe/process.py
+++ b/breathe/process.py
@@ -95,6 +95,6 @@ class AutoDoxygenProcessHandle(object):
         # Shell-escape the cfg file name to try to avoid any issue where the name might include
         # malicious shell character - We have to use the shell=True option to make it work on
         # Windows. See issue #271
-        self.run_process(b'doxygen %s' % quote(cfgfile), cwd=build_dir, shell=True)
+        self.run_process('doxygen %s' % quote(cfgfile), cwd=build_dir, shell=True)
 
         return self.path_handler.join(build_dir, name, "xml")

--- a/breathe/process.py
+++ b/breathe/process.py
@@ -84,6 +84,6 @@ class AutoDoxygenProcessHandle(object):
 
         self.write_file(build_dir, cfgfile, cfg)
 
-        self.run_process(['doxygen', cfgfile], cwd=build_dir)
+        self.run_process(['doxygen', cfgfile], cwd=build_dir, shell=True)
 
         return self.path_handler.join(build_dir, name, "xml")

--- a/breathe/process.py
+++ b/breathe/process.py
@@ -1,4 +1,12 @@
 
+from __future__ import unicode_literals
+
+try:
+    from shlex import quote  # py3
+except ImportError:
+    from pipes import quote  # py2
+
+
 AUTOCFG_TEMPLATE = r"""
 PROJECT_NAME     = "{project_name}"
 OUTPUT_DIRECTORY = {output_dir}
@@ -84,6 +92,9 @@ class AutoDoxygenProcessHandle(object):
 
         self.write_file(build_dir, cfgfile, cfg)
 
-        self.run_process(['doxygen', cfgfile], cwd=build_dir, shell=True)
+        # Shell-escape the cfg file name to try to avoid any issue where the name might include
+        # malicious shell character - We have to use the shell=True option to make it work on
+        # Windows. See issue #271
+        self.run_process(b'doxygen %s' % quote(cfgfile), cwd=build_dir, shell=True)
 
         return self.path_handler.join(build_dir, name, "xml")


### PR DESCRIPTION
This is @psifertex's changes plus my own adjustments for linux & test updates to get it working on travis.

@vitaut, does it seem reasonable to you? I think we need to merge the 'drop support for 2.6' either way as it isn't working on Travis and I believe it isn't worth supporting any more.