### PR TITLE
Fix handling of pending_xref non-type template parameters

### DIFF
--- a/breathe/apidoc.py
+++ b/breathe/apidoc.py
@@ -164,6 +164,7 @@ Note: By default this script will not overwrite already created files.""",
         for key, value in TYPEDICT.items():
             create_modules_toc_file(key, value, args)
 
+
 # So program can be started with "python -m breathe.apidoc ..."
 if __name__ == "__main__":
     main()

--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -17,6 +17,8 @@ class DoxygenTypeSub(supermod.DoxygenType):
 
     def __init__(self, version=None, compounddef=None):
         supermod.DoxygenType.__init__(self, version, compounddef)
+
+
 supermod.DoxygenType.subclass = DoxygenTypeSub
 # end class DoxygenTypeSub
 
@@ -41,6 +43,7 @@ class compounddefTypeSub(supermod.compounddefType):
                                           detaileddescription, inheritancegraph, collaborationgraph,
                                           programlisting, location, listofallmembers)
 
+
 supermod.compounddefType.subclass = compounddefTypeSub
 # end class compounddefTypeSub
 
@@ -51,6 +54,8 @@ class listofallmembersTypeSub(supermod.listofallmembersType):
 
     def __init__(self, member=None):
         supermod.listofallmembersType.__init__(self, member)
+
+
 supermod.listofallmembersType.subclass = listofallmembersTypeSub
 # end class listofallmembersTypeSub
 
@@ -61,6 +66,8 @@ class memberRefTypeSub(supermod.memberRefType):
 
     def __init__(self, virt=None, prot=None, refid=None, ambiguityscope=None, scope='', name=''):
         supermod.memberRefType.__init__(self, virt, prot, refid, ambiguityscope, scope, name)
+
+
 supermod.memberRefType.subclass = memberRefTypeSub
 # end class memberRefTypeSub
 
@@ -72,6 +79,8 @@ class compoundRefTypeSub(supermod.compoundRefType):
     def __init__(self, virt=None, prot=None, refid=None, valueOf_='', mixedclass_=None,
                  content_=None):
         supermod.compoundRefType.__init__(self, mixedclass_, content_)
+
+
 supermod.compoundRefType.subclass = compoundRefTypeSub
 # end class compoundRefTypeSub
 
@@ -82,6 +91,8 @@ class reimplementTypeSub(supermod.reimplementType):
 
     def __init__(self, refid=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.reimplementType.__init__(self, mixedclass_, content_)
+
+
 supermod.reimplementType.subclass = reimplementTypeSub
 # end class reimplementTypeSub
 
@@ -92,6 +103,8 @@ class incTypeSub(supermod.incType):
 
     def __init__(self, local=None, refid=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.incType.__init__(self, mixedclass_, content_)
+
+
 supermod.incType.subclass = incTypeSub
 # end class incTypeSub
 
@@ -106,6 +119,7 @@ class refTypeSub(supermod.refType):
 
         self.node_name = node_name
 
+
 supermod.refType.subclass = refTypeSub
 
 
@@ -117,6 +131,7 @@ class refTextTypeSub(supermod.refTextType):
                  content_=None):
         supermod.refTextType.__init__(self, mixedclass_, content_)
 
+
 supermod.refTextType.subclass = refTextTypeSub
 # end class refTextTypeSub
 
@@ -127,6 +142,7 @@ class sectiondefTypeSub(supermod.sectiondefType):
 
     def __init__(self, kind=None, header='', description=None, memberdef=None):
         supermod.sectiondefType.__init__(self, kind, header, description, memberdef)
+
 
 supermod.sectiondefType.subclass = sectiondefTypeSub
 # end class sectiondefTypeSub
@@ -228,6 +244,7 @@ class descriptionTypeSub(supermod.descriptionType):
                  content_=None):
         supermod.descriptionType.__init__(self, mixedclass_, content_)
 
+
 supermod.descriptionType.subclass = descriptionTypeSub
 # end class descriptionTypeSub
 
@@ -266,6 +283,7 @@ class enumvalueTypeSub(supermod.enumvalueType):
             self.set_initializer(obj_)
             self.content_.append(obj_)
 
+
 supermod.enumvalueType.subclass = enumvalueTypeSub
 # end class enumvalueTypeSub
 
@@ -276,6 +294,8 @@ class templateparamlistTypeSub(supermod.templateparamlistType):
 
     def __init__(self, param=None):
         supermod.templateparamlistType.__init__(self, param)
+
+
 supermod.templateparamlistType.subclass = templateparamlistTypeSub
 # end class templateparamlistTypeSub
 
@@ -287,6 +307,8 @@ class paramTypeSub(supermod.paramType):
     def __init__(self, type_=None, declname='', defname='', array='', defval=None,
                  briefdescription=None):
         supermod.paramType.__init__(self, type_, declname, defname, array, defval, briefdescription)
+
+
 supermod.paramType.subclass = paramTypeSub
 # end class paramTypeSub
 
@@ -297,6 +319,8 @@ class linkedTextTypeSub(supermod.linkedTextType):
 
     def __init__(self, ref=None, mixedclass_=None, content_=None):
         supermod.linkedTextType.__init__(self, mixedclass_, content_)
+
+
 supermod.linkedTextType.subclass = linkedTextTypeSub
 # end class linkedTextTypeSub
 
@@ -307,6 +331,8 @@ class graphTypeSub(supermod.graphType):
 
     def __init__(self, node=None):
         supermod.graphType.__init__(self, node)
+
+
 supermod.graphType.subclass = graphTypeSub
 # end class graphTypeSub
 
@@ -317,6 +343,8 @@ class nodeTypeSub(supermod.nodeType):
 
     def __init__(self, id=None, label='', link=None, childnode=None):
         supermod.nodeType.__init__(self, id, label, link, childnode)
+
+
 supermod.nodeType.subclass = nodeTypeSub
 # end class nodeTypeSub
 
@@ -327,6 +355,8 @@ class childnodeTypeSub(supermod.childnodeType):
 
     def __init__(self, relation=None, refid=None, edgelabel=None):
         supermod.childnodeType.__init__(self, relation, refid, edgelabel)
+
+
 supermod.childnodeType.subclass = childnodeTypeSub
 # end class childnodeTypeSub
 
@@ -337,6 +367,8 @@ class linkTypeSub(supermod.linkType):
 
     def __init__(self, refid=None, external=None, valueOf_=''):
         supermod.linkType.__init__(self, refid, external)
+
+
 supermod.linkType.subclass = linkTypeSub
 # end class linkTypeSub
 
@@ -347,6 +379,8 @@ class listingTypeSub(supermod.listingType):
 
     def __init__(self, codeline=None):
         supermod.listingType.__init__(self, codeline)
+
+
 supermod.listingType.subclass = listingTypeSub
 # end class listingTypeSub
 
@@ -357,6 +391,8 @@ class codelineTypeSub(supermod.codelineType):
 
     def __init__(self, external=None, lineno=None, refkind=None, refid=None, highlight=None):
         supermod.codelineType.__init__(self, external, lineno, refkind, refid, highlight)
+
+
 supermod.codelineType.subclass = codelineTypeSub
 # end class codelineTypeSub
 
@@ -367,6 +403,8 @@ class highlightTypeSub(supermod.highlightType):
 
     def __init__(self, class_=None, sp=None, ref=None, mixedclass_=None, content_=None):
         supermod.highlightType.__init__(self, mixedclass_, content_)
+
+
 supermod.highlightType.subclass = highlightTypeSub
 # end class highlightTypeSub
 
@@ -378,6 +416,8 @@ class referenceTypeSub(supermod.referenceType):
     def __init__(self, endline=None, startline=None, refid=None, compoundref=None, valueOf_='',
                  mixedclass_=None, content_=None):
         supermod.referenceType.__init__(self, mixedclass_, content_)
+
+
 supermod.referenceType.subclass = referenceTypeSub
 # end class referenceTypeSub
 
@@ -389,6 +429,8 @@ class locationTypeSub(supermod.locationType):
     def __init__(self, bodystart=None, line=None, bodyend=None, bodyfile=None, file=None,
                  valueOf_=''):
         supermod.locationType.__init__(self, bodystart, line, bodyend, bodyfile, file)
+
+
 supermod.locationType.subclass = locationTypeSub
 # end class locationTypeSub
 
@@ -400,6 +442,8 @@ class docSect1TypeSub(supermod.docSect1Type):
     def __init__(self, id=None, title='', para=None, sect2=None, internal=None, mixedclass_=None,
                  content_=None):
         supermod.docSect1Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docSect1Type.subclass = docSect1TypeSub
 # end class docSect1TypeSub
 
@@ -411,6 +455,8 @@ class docSect2TypeSub(supermod.docSect2Type):
     def __init__(self, id=None, title='', para=None, sect3=None, internal=None, mixedclass_=None,
                  content_=None):
         supermod.docSect2Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docSect2Type.subclass = docSect2TypeSub
 # end class docSect2TypeSub
 
@@ -422,6 +468,8 @@ class docSect3TypeSub(supermod.docSect3Type):
     def __init__(self, id=None, title='', para=None, sect4=None, internal=None, mixedclass_=None,
                  content_=None):
         supermod.docSect3Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docSect3Type.subclass = docSect3TypeSub
 # end class docSect3TypeSub
 
@@ -433,6 +481,8 @@ class docSect4TypeSub(supermod.docSect4Type):
     def __init__(self, id=None, title='', para=None, internal=None, mixedclass_=None,
                  content_=None):
         supermod.docSect4Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docSect4Type.subclass = docSect4TypeSub
 # end class docSect4TypeSub
 
@@ -443,6 +493,8 @@ class docInternalTypeSub(supermod.docInternalType):
 
     def __init__(self, para=None, sect1=None, mixedclass_=None, content_=None):
         supermod.docInternalType.__init__(self, mixedclass_, content_)
+
+
 supermod.docInternalType.subclass = docInternalTypeSub
 # end class docInternalTypeSub
 
@@ -453,6 +505,8 @@ class docInternalS1TypeSub(supermod.docInternalS1Type):
 
     def __init__(self, para=None, sect2=None, mixedclass_=None, content_=None):
         supermod.docInternalS1Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docInternalS1Type.subclass = docInternalS1TypeSub
 # end class docInternalS1TypeSub
 
@@ -463,6 +517,8 @@ class docInternalS2TypeSub(supermod.docInternalS2Type):
 
     def __init__(self, para=None, sect3=None, mixedclass_=None, content_=None):
         supermod.docInternalS2Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docInternalS2Type.subclass = docInternalS2TypeSub
 # end class docInternalS2TypeSub
 
@@ -473,6 +529,8 @@ class docInternalS3TypeSub(supermod.docInternalS3Type):
 
     def __init__(self, para=None, sect3=None, mixedclass_=None, content_=None):
         supermod.docInternalS3Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docInternalS3Type.subclass = docInternalS3TypeSub
 # end class docInternalS3TypeSub
 
@@ -483,6 +541,8 @@ class docInternalS4TypeSub(supermod.docInternalS4Type):
 
     def __init__(self, para=None, mixedclass_=None, content_=None):
         supermod.docInternalS4Type.__init__(self, mixedclass_, content_)
+
+
 supermod.docInternalS4Type.subclass = docInternalS4TypeSub
 # end class docInternalS4TypeSub
 
@@ -493,6 +553,8 @@ class docURLLinkSub(supermod.docURLLink):
 
     def __init__(self, url=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.docURLLink.__init__(self, mixedclass_, content_)
+
+
 supermod.docURLLink.subclass = docURLLinkSub
 # end class docURLLinkSub
 
@@ -503,6 +565,8 @@ class docAnchorTypeSub(supermod.docAnchorType):
 
     def __init__(self, id=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.docAnchorType.__init__(self, mixedclass_, content_)
+
+
 supermod.docAnchorType.subclass = docAnchorTypeSub
 # end class docAnchorTypeSub
 
@@ -513,6 +577,8 @@ class docFormulaTypeSub(supermod.docFormulaType):
 
     def __init__(self, id=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.docFormulaType.__init__(self, mixedclass_, content_)
+
+
 supermod.docFormulaType.subclass = docFormulaTypeSub
 # end class docFormulaTypeSub
 
@@ -523,6 +589,8 @@ class docIndexEntryTypeSub(supermod.docIndexEntryType):
 
     def __init__(self, primaryie='', secondaryie=''):
         supermod.docIndexEntryType.__init__(self, primaryie, secondaryie)
+
+
 supermod.docIndexEntryType.subclass = docIndexEntryTypeSub
 # end class docIndexEntryTypeSub
 
@@ -536,6 +604,8 @@ class docListTypeSub(supermod.docListType):
         if subtype is not "":
             self.node_subtype = subtype
         supermod.docListType.__init__(self, listitem)
+
+
 supermod.docListType.subclass = docListTypeSub
 # end class docListTypeSub
 
@@ -546,6 +616,8 @@ class docListItemTypeSub(supermod.docListItemType):
 
     def __init__(self, para=None):
         supermod.docListItemType.__init__(self, para)
+
+
 supermod.docListItemType.subclass = docListItemTypeSub
 # end class docListItemTypeSub
 
@@ -556,6 +628,8 @@ class docSimpleSectTypeSub(supermod.docSimpleSectType):
 
     def __init__(self, kind=None, title=None, para=None):
         supermod.docSimpleSectType.__init__(self, kind, title, para)
+
+
 supermod.docSimpleSectType.subclass = docSimpleSectTypeSub
 # end class docSimpleSectTypeSub
 
@@ -566,6 +640,8 @@ class docVarListEntryTypeSub(supermod.docVarListEntryType):
 
     def __init__(self, term=None):
         supermod.docVarListEntryType.__init__(self, term)
+
+
 supermod.docVarListEntryType.subclass = docVarListEntryTypeSub
 # end class docVarListEntryTypeSub
 
@@ -588,6 +664,7 @@ class docRefTextTypeSub(supermod.docRefTextType):
             obj_.build(child_)
             self.para.append(obj_)
 
+
 supermod.docRefTextType.subclass = docRefTextTypeSub
 # end class docRefTextTypeSub
 
@@ -598,6 +675,8 @@ class docTableTypeSub(supermod.docTableType):
 
     def __init__(self, rows=None, cols=None, row=None, caption=None):
         supermod.docTableType.__init__(self, rows, cols, row, caption)
+
+
 supermod.docTableType.subclass = docTableTypeSub
 # end class docTableTypeSub
 
@@ -608,6 +687,8 @@ class docRowTypeSub(supermod.docRowType):
 
     def __init__(self, entry=None):
         supermod.docRowType.__init__(self, entry)
+
+
 supermod.docRowType.subclass = docRowTypeSub
 # end class docRowTypeSub
 
@@ -618,6 +699,8 @@ class docEntryTypeSub(supermod.docEntryType):
 
     def __init__(self, thead=None, para=None):
         supermod.docEntryType.__init__(self, thead, para)
+
+
 supermod.docEntryType.subclass = docEntryTypeSub
 # end class docEntryTypeSub
 
@@ -648,6 +731,7 @@ class docHeadingTypeSub(supermod.docHeadingType):
             obj_.type_ = nodeName_
             self.content_.append(obj_)
 
+
 supermod.docHeadingType.subclass = docHeadingTypeSub
 # end class docHeadingTypeSub
 
@@ -659,6 +743,8 @@ class docImageTypeSub(supermod.docImageType):
     def __init__(self, width=None, type_=None, name=None, height=None, valueOf_='',
                  mixedclass_=None, content_=None):
         supermod.docImageType.__init__(self, mixedclass_, content_)
+
+
 supermod.docImageType.subclass = docImageTypeSub
 # end class docImageTypeSub
 
@@ -669,6 +755,8 @@ class docDotFileTypeSub(supermod.docDotFileType):
 
     def __init__(self, name=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.docDotFileType.__init__(self, mixedclass_, content_)
+
+
 supermod.docDotFileType.subclass = docDotFileTypeSub
 # end class docDotFileTypeSub
 
@@ -679,6 +767,8 @@ class docTocItemTypeSub(supermod.docTocItemType):
 
     def __init__(self, id=None, valueOf_='', mixedclass_=None, content_=None):
         supermod.docTocItemType.__init__(self, mixedclass_, content_)
+
+
 supermod.docTocItemType.subclass = docTocItemTypeSub
 # end class docTocItemTypeSub
 
@@ -689,6 +779,8 @@ class docTocListTypeSub(supermod.docTocListType):
 
     def __init__(self, tocitem=None):
         supermod.docTocListType.__init__(self, tocitem)
+
+
 supermod.docTocListType.subclass = docTocListTypeSub
 # end class docTocListTypeSub
 
@@ -699,6 +791,8 @@ class docLanguageTypeSub(supermod.docLanguageType):
 
     def __init__(self, langid=None, para=None):
         supermod.docLanguageType.__init__(self, langid, para)
+
+
 supermod.docLanguageType.subclass = docLanguageTypeSub
 # end class docLanguageTypeSub
 
@@ -709,6 +803,8 @@ class docParamListTypeSub(supermod.docParamListType):
 
     def __init__(self, kind=None, parameteritem=None):
         supermod.docParamListType.__init__(self, kind, parameteritem)
+
+
 supermod.docParamListType.subclass = docParamListTypeSub
 # end class docParamListTypeSub
 
@@ -719,6 +815,8 @@ class docParamListItemSub(supermod.docParamListItem):
 
     def __init__(self, parameternamelist=None, parameterdescription=None):
         supermod.docParamListItem.__init__(self, parameternamelist, parameterdescription)
+
+
 supermod.docParamListItem.subclass = docParamListItemSub
 # end class docParamListItemSub
 
@@ -729,6 +827,8 @@ class docParamNameListSub(supermod.docParamNameList):
 
     def __init__(self, parametername=None):
         supermod.docParamNameList.__init__(self, parametername)
+
+
 supermod.docParamNameList.subclass = docParamNameListSub
 # end class docParamNameListSub
 
@@ -739,6 +839,8 @@ class docParamNameSub(supermod.docParamName):
 
     def __init__(self, direction=None, ref=None, mixedclass_=None, content_=None):
         supermod.docParamName.__init__(self, mixedclass_, content_)
+
+
 supermod.docParamName.subclass = docParamNameSub
 # end class docParamNameSub
 
@@ -749,6 +851,8 @@ class docXRefSectTypeSub(supermod.docXRefSectType):
 
     def __init__(self, id=None, xreftitle=None, xrefdescription=None):
         supermod.docXRefSectType.__init__(self, id, xreftitle, xrefdescription)
+
+
 supermod.docXRefSectType.subclass = docXRefSectTypeSub
 # end class docXRefSectTypeSub
 
@@ -759,6 +863,8 @@ class docCopyTypeSub(supermod.docCopyType):
 
     def __init__(self, link=None, para=None, sect1=None, internal=None):
         supermod.docCopyType.__init__(self, link, para, sect1, internal)
+
+
 supermod.docCopyType.subclass = docCopyTypeSub
 # end class docCopyTypeSub
 
@@ -769,6 +875,8 @@ class docCharTypeSub(supermod.docCharType):
 
     def __init__(self, char=None, valueOf_=''):
         supermod.docCharType.__init__(self, char)
+
+
 supermod.docCharType.subclass = docCharTypeSub
 # end class docCharTypeSub
 
@@ -897,6 +1005,7 @@ class docParaTypeSub(supermod.docParaType):
             obj_.build(child_)
             self.content.append(obj_)
 
+
 supermod.docParaType.subclass = docParaTypeSub
 # end class docParaTypeSub
 
@@ -925,6 +1034,7 @@ class docMarkupTypeSub(supermod.docMarkupType):
         elif child_.nodeType == Node.CDATA_SECTION_NODE:
             self.valueOf_ += '![CDATA[' + child_.nodeValue + ']]'
 
+
 supermod.docMarkupType.subclass = docMarkupTypeSub
 # end class docMarkupTypeSub
 
@@ -936,6 +1046,7 @@ class docTitleTypeSub(supermod.docTitleType):
     def __init__(self, valueOf_='', mixedclass_=None, content_=None):
         supermod.docTitleType.__init__(self, valueOf_, mixedclass_, content_)
         self.type_ = None
+
 
 supermod.docTitleType.subclass = docTitleTypeSub
 # end class docTitleTypeSub

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -980,7 +980,7 @@ class SphinxRenderer(object):
         if node.type_:
             type_nodes = self.render(node.type_)
             # Render keywords as annotations for consistency with the cpp domain.
-            if len(type_nodes) > 0:
+            if len(type_nodes) > 0 and isinstance(type_nodes[0], six.text_type):
                 first_node = type_nodes[0]
                 for keyword in ['typename', 'class']:
                     if first_node.startswith(keyword + ' '):

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -208,6 +208,7 @@ breathe_projects = {
     "qtslots":"../../examples/specific/qtslots/xml/",
     "array":"../../examples/specific/array/xml/",
     "c_enum":"../../examples/specific/c_enum/xml/",
+    "multifile":"../../examples/specific/multifilexml/xml/",
     }
 
 breathe_projects_source = {

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -121,3 +121,11 @@ C Enum
 .. doxygenenum:: GSM_BackupFormat
    :project: c_enum
    :no-link:
+
+
+Multifile
+---------
+
+.. doxygenfunction:: TestTemplateFunction
+   :project: multifile
+   :no-link:

--- a/examples/specific/multifile/one/Util.h
+++ b/examples/specific/multifile/one/Util.h
@@ -8,3 +8,8 @@ void TestFunc() {};
 
 }
 
+class TestClass {
+public:
+    /// enum docs
+    enum Enum {};
+};

--- a/examples/specific/multifile/two/Util.h
+++ b/examples/specific/multifile/two/Util.h
@@ -1,3 +1,4 @@
+#include "../one/Util.h"
 
 namespace test {
 
@@ -7,3 +8,5 @@ struct TestStruct {};
 
 }
 
+/// The non-type template parameter references a different file
+template <TestClass::Enum E> void TestTemplateFunction();


### PR DESCRIPTION
I ran into the following error while generating docs for a function with a non-type template parameter:
```
Exception occurred:
  File ".../breathe/renderer/sphinxrenderer.py", line 986, in visit_param
    if first_node.startswith(keyword + ' '):
AttributeError: 'pending_xref' object has no attribute 'startswith'
```

As far as I can tell, the issue is specific to: user-defined types + template parameters + doxygen reference across files. The code added to `examples/specific/multifile` reproduces the problem (error message above) and the additional check in `sphinxrenderer.py` is a proposed fix.