### PR TITLE
Fix missing type in C typedefs

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -947,8 +947,18 @@ class SphinxRenderer(object):
         elif declaration.startswith(using):
             declaration = declaration[len(using):]
             obj_type = "using"
+
+        def update_signature(signature, obj_type):
+            """Update the signature node if necessary, e.g. add qualifiers."""
+            prefix = obj_type + ' '
+            annotation = self.node_factory.desc_annotation(prefix, prefix)
+            if signature[0].tagname != 'desc_annotation':
+                signature.insert(0, annotation)
+            else:
+                signature[0] = annotation
+
         return self.render_declaration(node, declaration, objtype=obj_type,
-                                       update_signature=self.update_signature)
+                                       update_signature=update_signature)
 
     def visit_variable(self, node):
         declaration = get_definition_without_template_args(node)

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -208,6 +208,7 @@ breathe_projects = {
     "qtslots":"../../examples/specific/qtslots/xml/",
     "array":"../../examples/specific/array/xml/",
     "c_enum":"../../examples/specific/c_enum/xml/",
+    "c_typedef":"../../examples/specific/c_typedef/xml/",
     }
 
 breathe_projects_source = {
@@ -225,6 +226,7 @@ breathe_domain_by_file_pattern = {
         "*/class.h" : "cpp",
         "*/alias.h" : "c",
         "*/c_enum.h" : "c",
+        "c_typedef.h" : "c",
         }
 
 

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -121,3 +121,10 @@ C Enum
 .. doxygenenum:: GSM_BackupFormat
    :project: c_enum
    :no-link:
+
+C Typedef
+---------
+
+.. doxygenfile:: c_typedef.h
+   :project: c_typedef
+   :no-link:

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -22,7 +22,7 @@ projects  = nutshell alias rst inline namespacefile c_file array c_enum inherita
 			members userdefined fixedwidthfont latexmath functionOverload \
 			image name union group struct struct_function qtslots lists \
 			headings links parameters template_class template_class_non_type \
-			template_function template_specialisation enum
+			template_function template_specialisation enum c_typedef
 
 special   = programlisting decl_impl multifilexml auto class typedef
 

--- a/examples/specific/c_typedef.cfg
+++ b/examples/specific/c_typedef.cfg
@@ -1,0 +1,11 @@
+PROJECT_NAME     = "Function Type Def Command"
+OUTPUT_DIRECTORY = c_typedef
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = c_typedef.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES

--- a/examples/specific/c_typedef.h
+++ b/examples/specific/c_typedef.h
@@ -1,0 +1,17 @@
+/**
+ * Sample typedef for a function pointer
+ */
+typedef int (*cTypeDefTestFuncPtr)(void);
+
+typedef void* (*cVoidFuncPtr)(float, int);
+
+typedef void* cVoidPointer;
+
+typedef float* cFloatPointer;
+
+typedef float cFloatingPointNumber;
+
+/**
+ * @brief Test for a simple C typedef
+ */
+typedef int cTestTypedef;


### PR DESCRIPTION
The type of a C typedef got overwritten with the typedef annotation itself.
Adding a specialised update_signature function for typedefs solves this.

This fixes #283 