### PR TITLE
Add initializers to variables

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -950,26 +950,32 @@ class SphinxRenderer(object):
         return self.render_declaration(node, declaration, objtype=obj_type,
                                        update_signature=self.update_signature)
 
+    def update_signature_with_initializer(self, signature, node):
+        initializer = node.initializer
+        if initializer:
+            nodes = self.render(initializer)
+            separator = ' '
+            if not nodes[0].startswith('='):
+                separator += '= '
+            signature.append(self.node_factory.Text(separator))
+            signature.extend(nodes)
+
     def visit_variable(self, node):
         declaration = get_definition_without_template_args(node)
         enum = 'enum '
         if declaration.startswith(enum):
             declaration = declaration[len(enum):]
-        return self.render_declaration(node, declaration)
+
+        def update_signature(signature, obj_type):
+            self.update_signature_with_initializer(signature, node)
+        return self.render_declaration(node, declaration, update_signature=update_signature)
 
     def visit_enumvalue(self, node):
         def update_signature(signature, obj_type):
             # Remove "class" from the signature. This is needed because Sphinx cpp domain doesn't
             # have an enum value directive and we use a class directive instead.
             signature.children.pop(0)
-            initializer = node.initializer
-            if initializer:
-                nodes = self.render(initializer)
-                separator = ' '
-                if not nodes[0].startswith('='):
-                    separator += '= '
-                signature.append(self.node_factory.Text(separator))
-                signature.extend(nodes)
+            self.update_signature_with_initializer(signature, node)
         return self.render_declaration(node, objtype='enumvalue', update_signature=update_signature)
 
     def visit_param(self, node):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -247,6 +247,6 @@ def test_render_const_func():
     assert '_CPPv2NK1fEv' in signature['ids']
 
 def test_render_variable_initializer():
-    member_def = TestMemberDef(kind='variable', definition='const int EOF', initializer='= -1')
+    member_def = TestMemberDef(kind='variable', definition='const int EOF', initializer=TestMixedContainer(value='= -1'))
     signature = find_node(render(member_def), 'desc_signature')
     assert signature.astext() == 'const int EOF = -1'

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -247,6 +247,6 @@ def test_render_const_func():
     assert '_CPPv2NK1fEv' in signature['ids']
 
 def test_render_variable_initializer():
-    member_def = TestMemberDef(kind='variable', definition='const int EOF', initializer=TestMixedContainer(value='= -1'))
+    member_def = TestMemberDef(kind='variable', definition='const int EOF', initializer=TestMixedContainer(value=u'= -1'))
     signature = find_node(render(member_def), 'desc_signature')
     assert signature.astext() == 'const int EOF = -1'

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -245,3 +245,8 @@ def test_render_const_func():
                                virt='non-virtual', const='yes')
     signature = find_node(render(member_def), 'desc_signature')
     assert '_CPPv2NK1fEv' in signature['ids']
+
+def test_render_variable_initializer():
+    member_def = TestMemberDef(kind='variable', definition='const int EOF', initializer='= -1')
+    signature = find_node(render(member_def), 'desc_signature')
+    assert signature.astext() == 'const int EOF = -1'


### PR DESCRIPTION
This was added to target something like the following ([demo here](https://packetio.readthedocs.io/en/latest/basics.html#_CPPv2N8packetio12PacketStream3EOFE))

```
struct Foo {
    static const int BAR = 1;
}
```

Is it undesirable for this to render for things that are not const?