### PR TITLE
Show base classes using the builtin sphinx cpp domain

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -8,12 +8,46 @@ import six
 import textwrap
 
 
+class DoxyCPPClassObject(cpp.CPPClassObject):
+    __bases = []
+
+    def parse_definition(self, parser):
+        # add the base classes
+        ast = parser.parse_declaration("class")
+
+        bases = []
+
+        for base in self.__bases:
+            namestr = base.content_[0].value
+
+            # build a name object
+            # TODO: work out if we can use base.refid in a pending_xref somewhere
+            try:
+                parser = cpp.DefinitionParser(namestr, self, self.env.config)
+            except TypeError:
+                # sphinx < 1.5
+                parser = cpp.DefinitionParser(namestr, self)
+            name = parser._parse_nested_name()
+            parser.assert_end()
+
+            bases.append(
+                cpp.ASTBaseClass(name, base.prot, base.virt == 'virtual', False)
+            )
+
+        ast.declaration.bases = bases
+
+        return ast
+
+    def augment(self, bases):
+        self.__bases = bases or []
+
+
 class DomainDirectiveFactory(object):
     # A mapping from node kinds to cpp domain classes and directive names.
     cpp_classes = {
-        'class': (cpp.CPPClassObject, 'class'),
-        'struct': (cpp.CPPClassObject, 'class'),
-        'interface': (cpp.CPPClassObject, 'interface'),
+        'class': (DoxyCPPClassObject, 'class'),
+        'struct': (DoxyCPPClassObject, 'class'),
+        'interface': (DoxyCPPClassObject, 'interface'),
         'function': (cpp.CPPFunctionObject, 'function'),
         'friend': (cpp.CPPFunctionObject, 'function'),
         'slot': (cpp.CPPFunctionObject, 'function'),
@@ -260,9 +294,12 @@ class SphinxRenderer(object):
         signode.extend(nodes)
         return signode
 
-    def run_domain_directive(self, kind, names):
+    def run_domain_directive(self, kind, names, augment=None):
         domain_directive = DomainDirectiveFactory.create(
             self.context.domain, [kind, names] + self.context.directive_args[2:])
+
+        if hasattr(domain_directive, 'augment') and augment is not None:
+            domain_directive.augment(**augment)
 
         # Translate Breathe's no-link option into the standard noindex option.
         if 'no-link' in self.context.directive_args[2]:
@@ -389,7 +426,13 @@ class SphinxRenderer(object):
         def render_signature(file_data, doxygen_target, name, kind):
             # Defer to domains specific directive.
             self.context.directive_args[1] = [self.get_fully_qualified_name()]
-            nodes = self.run_domain_directive(kind, self.context.directive_args[1])
+
+            if kind in ('class', 'struct'):
+                augment = dict(bases=file_data.compounddef.basecompoundref)
+            else:
+                augment = None
+
+            nodes = self.run_domain_directive(kind, self.context.directive_args[1], augment=augment)
             rst_node = nodes[1]
 
             finder = NodeFinder(rst_node.document)
@@ -507,7 +550,6 @@ class SphinxRenderer(object):
                     *intersperse(output, self.node_factory.Text(', '))
                 )
             )
-        render_list(node.basecompoundref, 'Inherits from ')
         render_list(node.derivedcompoundref, 'Subclassed by ')
 
         section_nodelists = {}


### PR DESCRIPTION
Tested on Sphinx 1.4.9, since #292 already breaks 1.5

This modifies the intermediate sphinx AST, rather than trying to build a string to push through the rst parser, or modifying the resulting rst AST.

Screenshot of this working:

![image](https://cloud.githubusercontent.com/assets/425260/21575057/5831fcce-cef8-11e6-889d-0b02d927da32.png)

Possible concern: This does not use `refid` in the same way that _"Inherits from ..."_ used to, instead allowing sphinx to do name resolution. I suspect this is ok, since doxygen seems to dump fully-qualified-names anyway.

---

This raises the point that perhaps we should use this technique in more places, intercepting everything at the AST level.

This does, however, leave us more vulnerable to implementation changes in sphinx
