### PR TITLE
Add option to control if define initializer is shown

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -637,7 +637,8 @@ class DoxygenDirectiveFactory(object):
             app.config.breathe_domain_by_extension,
             app.config.breathe_domain_by_file_pattern,
             app.config.breathe_projects_source,
-            app.config.breathe_build_directory
+            app.config.breathe_build_directory,
+            app.config.breathe_show_define_initializer
             )
 
 
@@ -822,6 +823,7 @@ def setup(app):
     app.add_config_value("breathe_projects_source", {}, True)
     app.add_config_value("breathe_build_directory", '', True)
     app.add_config_value("breathe_default_members", (), True)
+    app.add_config_value("breathe_show_define_initializer", False, 'env')
     app.add_config_value("breathe_implementation_filename_extensions", ['.c', '.cc', '.cpp'], True)
     app.add_config_value("breathe_doxygen_config_options", {}, True)
 

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -25,7 +25,8 @@ class AutoProjectInfo(object):
             config_dir,
             domain_by_extension,
             domain_by_file_pattern,
-            match
+            match,
+            show_define_initializer
             ):
 
         self._name = name
@@ -37,6 +38,7 @@ class AutoProjectInfo(object):
         self._domain_by_extension = domain_by_extension
         self._domain_by_file_pattern = domain_by_file_pattern
         self._match = match
+        self._show_define_initializer = show_define_initializer
 
     def name(self):
         return self._name
@@ -65,7 +67,8 @@ class AutoProjectInfo(object):
             self._config_dir,
             self._domain_by_extension,
             self._domain_by_file_pattern,
-            self._match
+            self._match,
+            self._show_define_initializer
             )
 
 
@@ -308,7 +311,8 @@ class ProjectInfoFactory(object):
                 self.config_dir,
                 self.domain_by_extension,
                 self.domain_by_file_pattern,
-                self.match
+                self.match,
+                self.show_define_initializer
             )
 
             self.auto_project_info_store[key] = auto_project_info

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -81,7 +81,8 @@ class ProjectInfo(object):
             config_dir,
             domain_by_extension,
             domain_by_file_pattern,
-            match
+            match,
+            show_define_initializer
             ):
 
         self._name = name
@@ -93,6 +94,7 @@ class ProjectInfo(object):
         self._domain_by_extension = domain_by_extension
         self._domain_by_file_pattern = domain_by_file_pattern
         self._match = match
+        self._show_define_initializer = show_define_initializer
 
     def name(self):
         return self._name
@@ -146,6 +148,9 @@ class ProjectInfo(object):
 
         return domain
 
+    def show_define_initializer(self):
+        return self._show_define_initializer
+
 
 class ProjectInfoFactory(object):
 
@@ -161,6 +166,8 @@ class ProjectInfoFactory(object):
         self.domain_by_extension = {}
         self.domain_by_file_pattern = {}
 
+        self.show_define_initializer = False
+
         self.project_count = 0
         self.project_info_store = {}
         self.project_info_for_auto_store = {}
@@ -173,7 +180,8 @@ class ProjectInfoFactory(object):
             domain_by_extension,
             domain_by_file_pattern,
             projects_source,
-            build_dir
+            build_dir,
+            show_define_initializer
             ):
 
         self.projects = projects
@@ -181,6 +189,7 @@ class ProjectInfoFactory(object):
         self.domain_by_extension = domain_by_extension
         self.domain_by_file_pattern = domain_by_file_pattern
         self.projects_source = projects_source
+        self.show_define_initializer = show_define_initializer
 
         # If the breathe config values has a non-empty value for build_dir then use that otherwise
         # stick with the default
@@ -241,7 +250,8 @@ class ProjectInfoFactory(object):
                 self.config_dir,
                 self.domain_by_extension,
                 self.domain_by_file_pattern,
-                self.match
+                self.match,
+                self.show_define_initializer
             )
 
             self.project_info_store[path] = project_info

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -925,7 +925,7 @@ class SphinxRenderer(object):
             declaration += ")"
 
         def update_define_signature(signature, obj_type):
-            if node.initializer:
+            if node.initializer and self.project_info.show_define_initializer():
                 signature.extend([self.node_factory.Text(" ")] + self.render(node.initializer))
 
         return self.render_declaration(node, declaration, update_signature=update_define_signature)

--- a/documentation/source/directives.rst
+++ b/documentation/source/directives.rst
@@ -507,3 +507,9 @@ Config Values
    would place ``EXCLUDE_SYMBOLS=abc123`` in the config file. The default value is
    the empty dictionary.
 
+.. confval:: breathe_show_define_initializer
+
+   A boolean flag which can be set to ``True`` to display the initializer of a define in the output.
+   
+   For example a define ``MAX_LENGTH 100`` would be shown with the value 100 if this is set to ``True``,
+   and without if it is set to ``False``.


### PR DESCRIPTION
As discussed in #319 , this adds a option to control if the initializer of a define is shown.

Currently its a global option called breathe_show_define_initializer in the conf.py file, I'm not sure if that's best way. A per project option might be better.

