### PR TITLE
Show reference qualification for methods

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -159,7 +159,8 @@ class memberdefTypeSub(supermod.memberdefType):
                  definition='', argsstring='', name='', read='', write='', bitfield='',
                  reimplements=None, reimplementedby=None, param=None, enumvalue=None,
                  initializer=None, exceptions=None, briefdescription=None, detaileddescription=None,
-                 inbodydescription=None, location=None, references=None, referencedby=None):
+                 inbodydescription=None, location=None, references=None, referencedby=None,
+                 refqual=None):
 
         supermod.memberdefType.__init__(self, initonly, kind, volatile, const, raise_, virt,
                                         readable, prot, explicit, new, final, writable, add, static,
@@ -168,7 +169,7 @@ class memberdefTypeSub(supermod.memberdefType):
                                         read, write, bitfield, reimplements, reimplementedby, param,
                                         enumvalue, initializer, exceptions, briefdescription,
                                         detaileddescription, inbodydescription, location,
-                                        references, referencedby)
+                                        references, referencedby, refqual)
 
         self.parameterlist = supermod.docParamListType.factory()
         self.parameterlist.kind = "param"

--- a/breathe/parser/compoundsuper.py
+++ b/breathe/parser/compoundsuper.py
@@ -1039,7 +1039,7 @@ class sectiondefType(GeneratedsSuper):
 class memberdefType(GeneratedsSuper):
     subclass = None
     superclass = None
-    def __init__(self, initonly=None, kind=None, volatile=None, const=None, raisexx=None, virt=None, readable=None, prot=None, explicit=None, new=None, final=None, writable=None, add=None, static=None, remove=None, sealed=None, mutable=None, gettable=None, inline=None, settable=None, id=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, param=None, enumvalue=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None):
+    def __init__(self, initonly=None, kind=None, volatile=None, const=None, raisexx=None, virt=None, readable=None, prot=None, explicit=None, new=None, final=None, writable=None, add=None, static=None, remove=None, sealed=None, mutable=None, gettable=None, inline=None, settable=None, id=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, param=None, enumvalue=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, refqual=None):
         self.initonly = initonly
         self.kind = kind
         self.volatile = volatile
@@ -1099,6 +1099,7 @@ class memberdefType(GeneratedsSuper):
             self.referencedby = []
         else:
             self.referencedby = referencedby
+        self.refqual = refqual
     def factory(*args_, **kwargs_):
         if memberdefType.subclass:
             return memberdefType.subclass(*args_, **kwargs_)
@@ -1199,6 +1200,8 @@ class memberdefType(GeneratedsSuper):
     def set_settable(self, settable): self.settable = settable
     def get_id(self): return self.id
     def set_id(self, id): self.id = id
+    def get_refqual(self): return self.refqual
+    def set_refqual(self, refqual): self.refqual = refqual
     def hasContent_(self):
         if (
             self.templateparamlist is not None or
@@ -1274,6 +1277,8 @@ class memberdefType(GeneratedsSuper):
             self.settable = attrs.get('settable').value
         if attrs.get('id'):
             self.id = attrs.get('id').value
+        if attrs.get('refqual'):
+            self.refqual = attrs.get('refqual').value
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'templateparamlist':

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -901,6 +901,11 @@ class SphinxRenderer(object):
         if node.volatile == 'yes' or node.argsstring.endswith('volatile'):
             signature += ' volatile'
 
+        if node.refqual == 'lvalue':
+            signature += '&';
+        elif node.refqual == 'rvalue':
+            signature += '&&';
+
         self.context.directive_args[1] = [signature]
 
         nodes = self.run_domain_directive(node.kind, self.context.directive_args[1])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -279,6 +279,34 @@ def test_render_const_func():
     assert '_CPPv2NK1fEv' in signature['ids']
 
 
+def test_render_lvalue_func():
+    member_def = TestMemberDef(kind='function', definition='void f', argsstring='()',
+                               virt='non-virtual', refqual='lvalue')
+    signature = find_node(render(member_def), 'desc_signature')
+    assert signature.astext().endswith('&')
+
+
+def test_render_rvalue_func():
+    member_def = TestMemberDef(kind='function', definition='void f', argsstring='()',
+                               virt='non-virtual', refqual='rvalue')
+    signature = find_node(render(member_def), 'desc_signature')
+    assert signature.astext().endswith('&&')
+
+
+def test_render_const_lvalue_func():
+    member_def = TestMemberDef(kind='function', definition='void f', argsstring='()',
+                               virt='non-virtual', const='yes', refqual='lvalue')
+    signature = find_node(render(member_def), 'desc_signature')
+    assert signature.astext().endswith('const &')
+
+
+def test_render_const_rvalue_func():
+    member_def = TestMemberDef(kind='function', definition='void f', argsstring='()',
+                               virt='non-virtual', const='yes', refqual='rvalue')
+    signature = find_node(render(member_def), 'desc_signature')
+    assert signature.astext().endswith('const &&')
+
+
 def test_render_variable_initializer():
     member_def = TestMemberDef(kind='variable', definition='const int EOF', initializer=TestMixedContainer(value=u'= -1'))
     signature = find_node(render(member_def), 'desc_signature')


### PR DESCRIPTION
Since C++11, one may specify if a method can be applied only to l-value or r-value objects. Doxygen sets a `refqual="..."` attribute on the function node of methods that are explicitly l-value or f-value qualified.

This PR adds support for Sphinx to understand that attribute and properly show the qualification in the generated documentation.