### PR TITLE
Fix sometimes nodes without a parent would be generated

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1100,7 +1100,8 @@ class SphinxRenderer(object):
         #
         # If there is no description then render then term by itself
         if nodelist:
-            nodelist[0].children = [term, separator] + nodelist[0].children
+            nodelist[0].insert(0, term)
+            nodelist[0].insert(1, separator)
         else:
             nodelist = [term]
 


### PR DESCRIPTION
This fixes the bug discussed here, where sometimes doc compilation would
crash when using recent Sphinx:

https://github.com/sphinx-doc/sphinx/issues/3709