### PR TITLE
Repair cppformat link after rename to fmt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,7 @@ Examples
 
 Examples of Breathe used by other projects:
 
-- `cppformat <http://cppformat.readthedocs.org/en/latest/>`_
-  [`pdf <https://media.readthedocs.org/pdf/cppformat/master/cppformat.pdf>`__]
+- `fmt <http://fmtlib.net/latest>`_
 - `Lasso C API <http://lassoguide.com/api/lcapi-reference.html>`_
   [`pdf <http://lassoguide.com/LassoGuide9.2.pdf>`__]
 


### PR DESCRIPTION
The 'cppformat' project renamed to 'fmt' and the readthedocs link in the README went dead. This PR points to the new documentation website for the project to repair the link. The PDF link is removed because it was so out of date, the linked PDF was from 2014 and several major versions ago, and there doesn't seem to be another more recently updated PDF version of the docs available online.

Also, thanks for creating Breathe! I really appreciate the project.