### PR TITLE
Don't generate pending xref on a compoundref with no refid

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -859,17 +859,18 @@ class SphinxRenderer(object):
 
         refid = self.get_refid(node.refid)
 
-        nodelist = [
-            self.node_factory.pending_xref(
-                "",
-                reftype="ref",
-                refdomain="std",
-                refexplicit=True,
-                refid=refid,
-                reftarget=refid,
-                *nodelist
-            )
-        ]
+        if refid is not None:
+            nodelist = [
+                self.node_factory.pending_xref(
+                    "",
+                    reftype="ref",
+                    refdomain="std",
+                    refexplicit=True,
+                    refid=refid,
+                    reftarget=refid,
+                    *nodelist
+                )
+            ]
 
         return nodelist
 


### PR DESCRIPTION
In some of my code I found an issue where Doxygen can generate a compoundref that does not have a refid value on it.  Some investigation showed that this was legal according to the xml schema:

```
<xsd:complexType name="compoundRefType">
  <xsd:simpleContent>
    <xsd:extension base="xsd:string">
      <xsd:attribute name="refid" type="xsd:string" use="optional" />
      <xsd:attribute name="prot" type="DoxProtectionKind" />
      <xsd:attribute name="virt" type="DoxVirtualKind" />
    </xsd:extension>
  </xsd:simpleContent>
</xsd:complexType>
```

So I have added a check for a refid before creating the pending xref, the end result is that generated doxygen that couldn't find a base class (that's where I found this) just spits out the name of the base class with no link.  Before this change it was causing an exception during the link resolution and aborting the sphinx build.