### PR TITLE
Use CPPEnumeratorObject which is provided by Sphinx since v1.3

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -22,9 +22,7 @@ class DomainDirectiveFactory(object):
         'using': (cpp.CPPTypeObject, 'type'),
         'union': (cpp.CPPTypeObject, 'type'),
         'namespace': (cpp.CPPTypeObject, 'type'),
-        # Use CPPClassObject for enum values as the cpp domain doesn't have a directive for
-        # enum values and CPPMemberObject requires a type.
-        'enumvalue': (cpp.CPPClassObject, 'member'),
+        'enumvalue': (cpp.CPPEnumeratorObject, 'enumerator'),
         'define': (c.CObject, 'macro')
     }
 

--- a/documentation/source/domains.rst
+++ b/documentation/source/domains.rst
@@ -158,10 +158,10 @@ Which create formatted output like:
 
 We can refer to **VALUE** using::
 
-   :cpp:member:`VALUE`
+   :cpp:enumerator:`VALUE`
    
-which renders as :cpp:member:`VALUE` and to **testnamespace::FIRST** using ::
+which renders as :cpp:enumerator:`VALUE` and to **testnamespace::FIRST** using ::
 
-   :cpp:member:`testnamespace::FIRST`
+   :cpp:enumerator:`testnamespace::FIRST`
 
-which renders as :cpp:member:`testnamespace::FIRST`.
+which renders as :cpp:enumerator:`testnamespace::FIRST`.


### PR DESCRIPTION
The comment said that “the cpp domain doesn't have a directive for enum values" however that is not true anymore. Enum support was added to the cpp domain in Sphinx 1.3 (early 2015), see sphinx-doc/sphinx#772.

This pull request also fixes breathe docs build failure with Sphinx 1.6.4, reported [here in Debian BTS](https://bugs.debian.org/877014).