### PR TITLE
More Robust Name Regex

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -104,7 +104,7 @@ def get_param_decl(param):
     if not param_name:
         param_decl = param_type
     else:
-        param_decl, number_of_subs = re.subn(r'(\([*&]+)(\))', r'\1' + param_name + r'\2',
+        param_decl, number_of_subs = re.subn(r'(\([*&]+)(\))', r'\g<1>' + param_name + r'\g<2>',
                                              param_type)
         if number_of_subs == 0:
             param_decl = param_type + ' ' + param_name


### PR DESCRIPTION
If the name passed into the sphinxrenderer regex happens to be a number, e.g. `1`, the regex fails.

Escaping the placeholders properly makes the regex more robust.