### PR TITLE
return parallel_{read,write}_safe true for sphinx

### DIFF
--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -13,4 +13,8 @@ def setup(app):
     from . import directives
 
     directives.setup(app)
-    return {'version': __version__}
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True
+    }


### PR DESCRIPTION
closes #141

on the few projects I have locally it works fine with this change
and calling sphinx with -j auto

I haven't examined all source code, this needs further testing