### PR TITLE
Adapt to newest Sphinx version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y doxygen texlive-latex-base texlive-latex-extra texlive-fonts-recommended
+  - sudo apt-get install -y doxygen texlive-latex-base texlive-latex-extra texlive-fonts-recommended latexmk
 
 install:
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
 language: python
 
 env:
-  - SPHINX_VERSION=1.4 TRAVIS_CI=True
-  - SPHINX_VERSION=1.5 TRAVIS_CI=True
+  - SPHINX_VERSION=1.7 TRAVIS_CI=True
 
 python:
   - "2.7"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -59,9 +59,16 @@ class MockConfig(object):
     cpp_index_common_prefix = []
 
 
+class MockApp(object):
+    def __init__(self):
+        self.doctreedir = None
+        self.srcdir = None
+        self.config = MockConfig()
+
+
 class MockState:
     def __init__(self):
-        env = sphinx.environment.BuildEnvironment(None, None, MockConfig())
+        env = sphinx.environment.BuildEnvironment(MockApp())
         CPPDomain(env)
         CDomain(env)
         env.temp_data['docname'] = 'mock-doc'


### PR DESCRIPTION
It looks like the CI was testing against old, unsupported Sphinx versions. Generating the documentation results in *a lot* of warnings that were not there before:
- Duplicate declarations. This is not a new problem, but now there are warnings about it. See sphinx-doc/sphinx#4820 and sphinx-doc/sphinx#4981. When the Sphinx support for aliases is implemented I suggest that Breathe directives get an ``:alias:`` for specifying that no declarations should be inserted, but only aliases.
- Error in expression: ``int bar(int n, int a[static n])``. Also a warning about an old problem.

Fixes #360 
See also #374 that will be fixed when upgrading the Sphinx version.