### PR TITLE
Add support for QtSignals

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -799,7 +799,7 @@ class SphinxRenderer(object):
                 rst_node = self.node_factory.displaymath()
 
             # Or multiline
-            if latex.startswith("\[") and latex.endswith("\]"):
+            if latex.startswith("\\[") and latex.endswith("\\]"):
                 latex = latex[2:-2:]
 
             # Here we steal the core of the mathbase "math" directive handling code from:

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -72,6 +72,7 @@ class DomainDirectiveFactory(object):
         'interface': (DoxyCPPClassObject, 'interface'),
         'function': (cpp.CPPFunctionObject, 'function'),
         'friend': (cpp.CPPFunctionObject, 'function'),
+        'signal': (cpp.CPPFunctionObject, 'function'),
         'slot': (cpp.CPPFunctionObject, 'function'),
         'enum': (cpp.CPPTypeObject, 'type'),
         'typedef': (cpp.CPPTypeObject, 'type'),
@@ -547,7 +548,7 @@ class SphinxRenderer(object):
         ("public-func", "Public Functions"),
         ("public-attrib", "Public Members"),
         ("public-slot", "Public Slots"),
-        ("signal", "Signal"),
+        ("signal", "Signals"),
         ("dcop-func", "DCOP Function"),
         ("property", "Property"),
         ("event", "Event"),
@@ -1236,7 +1237,7 @@ class SphinxRenderer(object):
 
     def dispatch_memberdef(self, node):
         """Dispatch handling of a memberdef node to a suitable visit method."""
-        if node.kind in ("function", "slot") or \
+        if node.kind in ("function", "signal", "slot") or \
                 (node.kind == 'friend' and node.argsstring):
             return self.visit_function(node)
         if node.kind == "enum":

--- a/documentation/source/class.rst
+++ b/documentation/source/class.rst
@@ -221,23 +221,23 @@ It produces this output:
    :no-link:
 
 
-Qt Slots Example
-----------------
+Qt Signals & Slots Example
+--------------------------
 
-Doxygen is aware of Qt Slots and so Breathe can pick them up and display them in
-the output. They are displayed in appropriate ``Public Slots``, ``Protected
-Slots`` and ``Private Slots`` sections.
+Doxygen is aware of Qt Signals and Slots and so Breathe can pick them up and
+display them in the output. They are displayed in appropriate ``Signals``,
+``Public Slots``, ``Protected Slots`` and ``Private Slots`` sections.
 
 .. code-block:: rst
 
-   .. doxygenclass:: QtSlotExample
-      :project: qtslots
+   .. doxygenclass:: QtSignalSlotExample
+      :project: qtsignalsandslots
       :members:
 
 Produces the following output:
 
-.. doxygenclass:: QtSlotExample
-   :project: qtslots
+.. doxygenclass:: QtSignalSlotExample
+   :project: qtsignalsandslots
    :members:
    :no-link:
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -206,7 +206,7 @@ breathe_projects = {
     "lists":"../../examples/specific/lists/xml/",
     "group":"../../examples/specific/group/xml/",
     "union":"../../examples/specific/union/xml/",
-    "qtslots":"../../examples/specific/qtslots/xml/",
+    "qtsignalsandslots":"../../examples/specific/qtsignalsandslots/xml/",
     "array":"../../examples/specific/array/xml/",
     "c_enum":"../../examples/specific/c_enum/xml/",
     "c_typedef":"../../examples/specific/c_typedef/xml/",

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -20,7 +20,7 @@ HAVE_DOT  = /usr/bin/dot
 
 projects  = nutshell alias rst inline namespacefile c_file array c_enum inheritance \
 			members userdefined fixedwidthfont latexmath functionOverload \
-			image name union group struct struct_function qtslots lists \
+			image name union group struct struct_function qtsignalsandslots lists \
 			headings links parameters template_class template_class_non_type \
 			template_function template_specialisation enum c_typedef define interface
 

--- a/examples/specific/qtsignalsandslots.cfg
+++ b/examples/specific/qtsignalsandslots.cfg
@@ -1,10 +1,10 @@
-PROJECT_NAME     = "Qt Slots"
-OUTPUT_DIRECTORY = qtslots
+PROJECT_NAME     = "Qt Signals & Slots"
+OUTPUT_DIRECTORY = qtsignalsandslots
 GENERATE_LATEX   = NO
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO
 CASE_SENSE_NAMES = NO
-INPUT            = qtslots.h
+INPUT            = qtsignalsandslots.h
 QUIET            = YES
 JAVADOC_AUTOBRIEF = YES
 GENERATE_HTML = NO

--- a/examples/specific/qtsignalsandslots.h
+++ b/examples/specific/qtsignalsandslots.h
@@ -3,7 +3,7 @@
 
 #include
 
-class QtSlotExample: public QObject
+class QtSignalSlotExample: public QObject
 {
     Q_OBJECT
 
@@ -14,6 +14,14 @@ class QtSlotExample: public QObject
      This is shown in declaration
      */
     void workingFunction( int iShownParameter ) { Q_UNUSED( iShownParameter ; ) }
+
+    signals:
+
+    /*!
+     *\param iShown
+     This is in function declaration
+     */
+    void workingSignal( int iShown );
 
     public slots:
 


### PR DESCRIPTION
This change adds proper support for QtSignals by treating signals as functions (similar to what has been done for QtSlots in https://github.com/michaeljones/breathe/commit/b584c324ea1d19110a2398a422d0a3cdf5c1cc09).

In addition change the example for QtSlots to QtSignalsAndSlots so that both signals and slots are properly documented and validated.

Without this change breathe emits the following warnings for classes
that contain signals:

```
WARNING: Error in declarator or parameters and qualifiers
If pointer to member declarator:
  Invalid definition: Expected identifier in nested name. [error at 34]
      QtSignalSlotExample::workingSignal
          ----------------------------------^
```