### PR TITLE
fix flake8 F632 warnings

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -602,7 +602,7 @@ class docListTypeSub(supermod.docListType):
 
     def __init__(self, listitem=None, subtype=""):
         self.node_subtype = "itemized"
-        if subtype is not "":
+        if subtype != "":
             self.node_subtype = subtype
         supermod.docListType.__init__(self, listitem)
 

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -931,10 +931,10 @@ class SphinxRenderer(object):
         decorator around the generic render function.
         Render all the children depth-first. """
         """ Call the wrapped render function. Update the nesting level for the enumerated lists. """
-        if node.node_subtype is "itemized":
+        if node.node_subtype == "itemized":
             val = self.render_iterable(node.listitem)
             return self.render_unordered(children=val)
-        elif node.node_subtype is "ordered":
+        elif node.node_subtype == "ordered":
             self.nesting_level += 1
             val = self.render_iterable(node.listitem)
             self.nesting_level -= 1


### PR DESCRIPTION
this may fix actually be a bugfix due to the nature of the `is` operator