### PR TITLE
Add support for rendering parameter direction information

### DIFF
--- a/breathe/parser/compoundsuper.py
+++ b/breathe/parser/compoundsuper.py
@@ -5445,6 +5445,11 @@ class docParamName(GeneratedsSuper):
             obj_ = self.mixedclass_(MixedContainer.CategoryText,
                 MixedContainer.TypeNone, '', child_.nodeValue)
             self.content_.append(obj_)
+            d = child_.parentNode.attributes.get('direction')
+            if d is not None:
+                self.content_.insert(0, self.mixedclass_(MixedContainer.CategoryText,
+                                                         MixedContainer.TypeNone,
+                                                         '', '[{}] '.format(d.value)))
 # end class docParamName
 
 

--- a/examples/doxygen/func.h
+++ b/examples/doxygen/func.h
@@ -19,3 +19,11 @@ const char *Test6::member(char c,int n) throw(std::out_of_range) {}
  *  \exception std::out_of_range parameter is out of range.
  *  \return a character pointer.
  */
+
+/*! \brief Doing important things with parameter directions
+ *
+ *  \param[out]     a output
+ *  \param[in]      b input
+ *  \param[in, out] c input but gets rewritten
+ */
+void myFunc(int * a, int * b, int * c);


### PR DESCRIPTION
Close #269.

This now gives 
![grafik](https://user-images.githubusercontent.com/1185677/55974760-ab414580-5c88-11e9-9616-41f6fb295508.png)
