### PR TITLE
Fix for template method pointer parameter issue

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -193,7 +193,7 @@ def get_param_decl(param):
     if not param_name:
         param_decl = param_type
     else:
-        param_decl, number_of_subs = re.subn(r'(\([*&]+)(\))', r'\g<1>' + param_name + r'\g<2>',
+        param_decl, number_of_subs = re.subn(r'(\((?:\w+::)*[*&]+)(\))', r'\g<1>' + param_name + r'\g<2>',
                                              param_type)
         if number_of_subs == 0:
             param_decl = param_type + ' ' + param_name

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -193,7 +193,8 @@ def get_param_decl(param):
     if not param_name:
         param_decl = param_type
     else:
-        param_decl, number_of_subs = re.subn(r'(\((?:\w+::)*[*&]+)(\))', r'\g<1>' + param_name + r'\g<2>',
+        param_decl, number_of_subs = re.subn(r'(\((?:\w+::)*[*&]+)(\))',
+                                             r'\g<1>' + param_name + r'\g<2>',
                                              param_type)
         if number_of_subs == 0:
             param_decl = param_type + ' ' + param_name


### PR DESCRIPTION
I have found that Breathe does not cope with a template method pointer parameter.

The method signature of `bad()` below causes the issue.

```c++
/**
 * A class.
 */
class C {
public:
    /**
     * Set a callback. This causes a breathe error.
     *
     * \tparam OWNER Class the declares \p callback.
     * \param owner Reference to the object to call \p callback on.
     * \param callback Pointer to callback method.
     */
    template <typename OWNER>
    void bad(OWNER& owner, void (OWNER::*callback)(void));


    /**
     * No error from this because does not have method pointer param.
     *
     * \tparam OWNER Class the declares \p callback.
     * \param owner Reference to the object to call \p callback on.
     * \param v Some parameter.
     */
    template <typename OWNER>
    void fine(OWNER& owner, int v);
};
```

This is the Sphinx source to reproduce the error:

```rst
Welcome to breathe-issue's documentation!
=========================================

Doco for C:

.. doxygenclass:: C
    :members:
```

And this is the warning reported by Sphinx:

```
index.rst:6: WARNING: Error when parsing function declaration.
If the function has no return type:
  Error in declarator or parameters and qualifiers
  Invalid definition: Expected identifier in nested name, got keyword: void [error at 28]
    template<typename OWNER>void C::bad(OWNER & owner, void(OWNER::*)(void) callback)
    ----------------------------^
If the function has a return type:
  Error in declarator or parameters and qualifiers
  If pointer to member declarator:
    Invalid definition: Expected '::' in pointer to member (function). [error at 35]
      template<typename OWNER>void C::bad(OWNER & owner, void(OWNER::*)(void) callback)
      -----------------------------------^
  If declarator-id:
    Invalid definition: Expecting "," or ")" in parameters_and_qualifiers, got "c". [error at 72]
      template<typename OWNER>void C::bad(OWNER & owner, void(OWNER::*)(void) callback)
      ------------------------------------------------------------------------^
looking for now-outdated files... none found
```

The proposed fix is just a tweak to the regex that is trying to match a function pointer parameter type.

Please let me know if there is anything else I can do to help on this.

Thanks for providing Breathe too!
