### PR TITLE
Add events attribute to MockApp

### DIFF
--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -77,6 +77,7 @@ class MockApp(object):
         self.config.add('cpp_paren_attributes', [], 'env', ())
         self.config.add('cpp_index_common_prefix', [], 'env', ())
         self.registry = MockRegistry()
+        self.events = None
 
     def add_node(self, node):
         if not docutils.is_node_registered(node):


### PR DESCRIPTION
When updating python-breathe for Fedora, I noticed that the test suite fails with errors like this:
```
======================================================================
ERROR: test_renderer.test_render_define_no_initializer
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/builddir/build/BUILD/breathe-4.13.1/tests/test_renderer.py", line 381, in test_render_define_no_initializer
    signature = find_node(render(member_def), 'desc_signature')
  File "/builddir/build/BUILD/breathe-4.13.1/tests/test_renderer.py", line 255, in render
    renderer.context = MockContext([member_def], domain)
  File "/builddir/build/BUILD/breathe-4.13.1/tests/test_renderer.py", line 137, in __init__
    MockState(), MockStateMachine()]
  File "/builddir/build/BUILD/breathe-4.13.1/tests/test_renderer.py", line 88, in __init__
    env = sphinx.environment.BuildEnvironment(MockApp())
  File "/usr/lib/python3.8/site-packages/sphinx/environment/__init__.py", line 192, in __init__
    self.setup(app)
  File "/usr/lib/python3.8/site-packages/sphinx/environment/__init__.py", line 218, in setup
    self.events = app.events
AttributeError: 'MockApp' object has no attribute 'events'
```

This appears to be caused by Fedora shipping Sphinx 2.1.2 now. Adding the `events` attribute to `MockApp` fixes this issue and the tests pass again.