### PR TITLE
Fix test failure for Sphinx >= 2.2.2

### DIFF
--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -62,7 +62,7 @@ class MockRegistry(object):
         return None
 
     def create_domains(self, env):
-        return []
+        return [CDomain(env), CPPDomain(env)]
 
 
 class MockApp(object):
@@ -86,9 +86,9 @@ class MockApp(object):
 
 class MockState:
     def __init__(self):
-        env = sphinx.environment.BuildEnvironment(MockApp())
-        CPPDomain(env)
-        CDomain(env)
+        app = MockApp()
+        env = sphinx.environment.BuildEnvironment(app)
+        env.setup(app)
         env.temp_data['docname'] = 'mock-doc'
         settings = frontend.OptionParser(
             components=(parsers.rst.Parser,)).get_default_values()


### PR DESCRIPTION
This fixes #465.

Sphinx changed the way it retrieves the CDomain in
https://github.com/sphinx-doc/sphinx/commit/e42d546685e7baae3c2618e81152e8a8bdc17ead
to no longer use env.domaindata, but env.get_domain instead.

This breaks the mocks setup by breathe as they were implicitly only populatin
env.domaindata by invoking the constructor of the C and C++ domains (see
sphinx.domains.__init__: Domain.__init__). To properly populate the environment,
we need to make the mocked registry aware of the registered domains. Since we
only care about the C and C++ domain, we simply make it return both in
create_domains(), which registers them properly in the environment.

Note that this is unfortunately only a hack and a proper solution would be to port the testsuite to use sphinx' [`testing`](https://www.sphinx-doc.org/en/master/devguide.html#unit-testing) module instead, which in turn requires to use pytest instead of nosetests.