### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,33 @@
+name: build the documentation
+on: [push, pull_request]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: set up python
+        uses: actions/setup-python@v1
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements/development.txt
+          sudo apt -y install doxygen
+
+      - name: build the documentation
+        run: |
+          make html
+          rm documentation/build/html/.buildinfo
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: documentation
+          path: documentation/build/html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint using flake8
+on: [push, pull_request]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: set up python
+        uses: actions/setup-python@v1
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements/development.txt
+          pip install flake8
+
+      - name: lint the source code
+        run: make flake8

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,55 @@
+name: unit tests
+on: [push, pull_request]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        sphinx-version:
+          - 2.0.0
+          - 2.0.1
+          - 2.1.0
+          - 2.1.1
+          - 2.1.2
+          - 2.2.0
+          - 2.2.1
+          - 2.2.2
+          - 2.3.0
+          - 2.3.1
+          # FIXME: the unit tests are currently failing in the development
+          # branches
+          # development branch for sphinx 2.4
+          # - git+https://github.com/sphinx-doc/sphinx.git@2.0
+          # development branch for sphinx 3
+          # - git+https://github.com/sphinx-doc/sphinx.git@master
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: install sphinx from PyPI or from git
+        run: |
+          if echo "${{ matrix.sphinx-version }}"|grep -q git; then
+              pip install ${{ matrix.sphinx-version }}
+          else
+              pip install -Iv Sphinx==${{ matrix.sphinx-version }}
+          fi
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements/development.txt
+          pip install nose
+
+      - name: run the unit tests
+        run: make dev-test

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,9 @@ Breathe
 .. image:: https://travis-ci.org/michaeljones/breathe.svg?branch=master
     :target: https://travis-ci.org/michaeljones/breathe
 
+.. image:: https://github.com/michaeljones/breathe/workflows/unit%20tests/badge.svg
+    :target: https://github.com/michaeljones/breathe/actions?query=workflow%3A%22unit+tests%22
+
 This is an extension to reStructuredText and Sphinx to be able to read and
 render the Doxygen xml output.
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=1.8
+Sphinx>=2.0
 six>=1.9.0


### PR DESCRIPTION
To prevent issues due to changes in sphinx between compatible versions, I've created a github action workflow that will run the tests against all supported sphinx versions and all supported python versions. Running the tests against Sphinx 1.8.x actually failed, so I raised the required version to 2.0.

Furthermore, I've added workflows to build breathe's documentation and run flake8.

Example runs: https://github.com/D4N/breathe/actions