### PR TITLE
nose added to development requirements

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,3 +1,4 @@
 -r production.txt
 
 pip-tools>=0.3.5
+nose


### PR DESCRIPTION
`nose` seems to be needed to run unit tests. But even with it installed I get the following errors:

```
Traceback (most recent call last):
  File "/home/mpusz/.local/lib/python3.7/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/mpusz/repos/breathe/tests/test_renderer.py", line 333, in test_render_rvalue_func
    signature = find_node(render(member_def), 'desc_signature')
  File "/home/mpusz/repos/breathe/tests/test_renderer.py", line 257, in render
    return renderer.render(member_def)
  File "/home/mpusz/repos/breathe/breathe/renderer/sphinxrenderer.py", line 1308, in render
    result = method(self, node)
  File "/home/mpusz/repos/breathe/breathe/renderer/sphinxrenderer.py", line 1245, in dispatch_memberdef
    return self.visit_function(node)
  File "/home/mpusz/repos/breathe/breathe/renderer/sphinxrenderer.py", line 1024, in visit_function
    nodes = self.run_domain_directive(node.kind, self.context.directive_args[1])
  File "/home/mpusz/repos/breathe/breathe/renderer/sphinxrenderer.py", line 357, in run_domain_directive
    nodes = domain_directive.run()
  File "/home/mpusz/.local/lib/python3.7/site-packages/sphinx/domains/cpp.py", line 6294, in run
    return super().run()
  File "/home/mpusz/.local/lib/python3.7/site-packages/sphinx/directives/__init__.py", line 196, in run
    self.env.app.emit('object-description-transform',
AttributeError: 'MockApp' object has no attribute 'emit'
```

Is there something else missing?