### PR TITLE
Fixes to use Sphinx 2.4.4

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,13 +17,14 @@ jobs:
           - 2.2.1
           - 2.2.2
           - 2.3.0
-          - 2.3.1
-          # FIXME: the unit tests are currently failing in the development
-          # branches
-          # development branch for sphinx 2.4
-          # - git+https://github.com/sphinx-doc/sphinx.git@2.0
-          # development branch for sphinx 3
-          # - git+https://github.com/sphinx-doc/sphinx.git@master
+          - 2.4.0
+          - 2.4.1
+          - 2.4.2
+          - 2.4.3
+          - 2.4.4
+          - git+https://github.com/sphinx-doc/sphinx.git@2.x
+          #- git+https://github.com/sphinx-doc/sphinx.git@3.x
+          #- git+https://github.com/sphinx-doc/sphinx.git@master
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 env:
-  - SPHINX_VERSION=2.3.1 TRAVIS_CI=True
+  - SPHINX_VERSION=2.4.4 TRAVIS_CI=True
 
 python:
   - "3.5"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -83,6 +83,9 @@ class MockApp(object):
         if not docutils.is_node_registered(node):
             docutils.register_node(node)
 
+    def emit(self, name, *args):
+        print('[MockApp] was supposed to emit event: %r%s' % (name, repr(args)[:100]))
+
 
 class MockState:
     def __init__(self):


### PR DESCRIPTION
Update CI to check the whole Sphinx 2 series (though only the newest is officially supported), and appropriate fixes to mocks.