### PR TITLE
strictly depend on sphinx's minor version

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=3.0
+Sphinx>=3.0,<3.1
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<3.1', 'docutils>=0.12', 'six>=1.9']
 
 if sys.version_info < (3, 5):
     print('ERROR: Sphinx requires at least Python 3.5 to run.')


### PR DESCRIPTION
Breathe closely integrates with many of Sphinx's internals, especially
integration with Sphinx's C and C++ domains is rather fragile. Changes
often need to be made in both Breathe and Sphinx at the same time.

By pinning the Sphinx minor version in the dependency list it is ensured
only versions that have been (mostly) verified to be compatible with
each other are used, which prevents unexpected breakage. This is often
the case if only Breathe's or only Sphinx's version is pinned in a
project's dependency list.