### PR TITLE
Fix friend class rendering and allow 'friend struct'

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1517,13 +1517,14 @@ class SphinxRenderer(object):
         dom = self.get_domain()
         assert not dom or dom == 'cpp'
 
-        assert ''.join(n.astext() for n in self.render(node.get_type())) == "friend class"
         desc = self.node_factory.desc()
         desc['objtype'] = 'friendclass'
         signode = self.node_factory.desc_signature()
         desc += signode
 
-        signode += self.node_factory.desc_annotation('friend class')
+        typ = ''.join(n.astext() for n in self.render(node.get_type()))
+        assert typ in ("friend class", "friend struct")
+        signode += self.node_factory.desc_annotation(typ, typ)
         signode += self.node_factory.Text(' ')
         # expr = cpp.CPPExprRole(asCode=False)
         # expr.text = node.name

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -219,6 +219,7 @@ breathe_projects = {
     "cpp_enum":"../../examples/specific/cpp_enum/xml/",
     "cpp_union":"../../examples/specific/cpp_union/xml/",
     "cpp_function":"../../examples/specific/cpp_function/xml/",
+    "cpp_friendclass":"../../examples/specific/cpp_friendclass/xml/",
     "cpp_inherited_members":"../../examples/specific/cpp_inherited_members/xml/",
     "cpp_trailing_return_type":"../../examples/specific/cpp_trailing_return_type/xml/",
     }

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -203,6 +203,14 @@ C++ Functions
 .. doxygenfile:: cpp_function.h
    :project: cpp_function
 
+C++ Friend Classes
+------------------
+
+.. cpp:namespace:: @ex_specific_cpp_friendclass
+
+.. doxygenfile:: cpp_friendclass.h
+   :project: cpp_friendclass
+
 C++ Inherited Members
 ---------------------
 

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -24,8 +24,8 @@ projects  = nutshell alias rst inline namespacefile array inheritance \
 			headings links parameters template_class template_class_non_type \
 			template_function template_type_alias template_specialisation \
 			enum define interface \
-			cpp_anon cpp_enum cpp_union cpp_function cpp_inherited_members \
-			cpp_trailing_return_type \
+			cpp_anon cpp_enum cpp_union cpp_function cpp_friendclass \
+			cpp_inherited_members cpp_trailing_return_type \
 			c_file c_struct c_enum c_typedef c_macro c_union
 
 special   = programlisting decl_impl multifilexml auto class typedef

--- a/examples/specific/cpp_friendclass.cfg
+++ b/examples/specific/cpp_friendclass.cfg
@@ -1,0 +1,11 @@
+PROJECT_NAME     = "C++ Friend Class"
+OUTPUT_DIRECTORY = cpp_friendclass
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = cpp_friendclass.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES

--- a/examples/specific/cpp_friendclass.h
+++ b/examples/specific/cpp_friendclass.h
@@ -1,0 +1,7 @@
+struct A {};
+struct B {};
+
+struct C {
+	friend class A;
+	friend struct B;
+};


### PR DESCRIPTION
Allow "friend struct" as well as "friend class", and actually show the annotation in the output.

Fixes #521.