### PR TITLE
Render function candidates without using Sphinx directives

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -3,8 +3,9 @@ from ..renderer.base import RenderContext
 from ..renderer import format_parser_error, DoxygenToRstRendererFactory
 from ..parser import ParserError, FileIOError
 
+from sphinx.directives import SphinxDirective
+
 from docutils import nodes
-from docutils.parsers import rst
 
 
 class WarningHandler(object):
@@ -44,12 +45,12 @@ def create_warning(project_info, state, lineno, **kwargs):
     return WarningHandler(state, context)
 
 
-class BaseDirective(rst.Directive):
+class BaseDirective(SphinxDirective):
 
     def __init__(self, finder_factory,
                  project_info_factory, filter_factory, target_handler_factory, parser_factory,
                  *args):
-        rst.Directive.__init__(self, *args)
+        super().__init__(*args)
         self.directive_args = list(args)  # Convert tuple to list to allow modification.
 
         self.finder_factory = finder_factory


### PR DESCRIPTION
The ``doxygenfunction`` directive works by
1. finding all functions in the XML which matches the given name (without potential parameters)
2. rendered each to docutil first nodes, and then converted the nodes to a string. The docutil nodes are discarded.
3. the string is then parsed and an attempt at matching the parameters with the given parameters is made (this is where #289 is relevant).

Step 2 was performed using the normal rendering machinery, meaning Sphinx is told about the declarations, without them being present in the output. This results is "Duplicate declaration" warnings.

This PR uses the ``DefinitionParser`` from the C++ domain to directly parse the function signature without using the domain directives.

Fixes #504 and perhaps also #458.

(The change of base class for the ``BaseDirective`` to ``SphinxDirective`` is to get convenient access to location and config data.)