### PR TITLE
Extern examples and hax removal

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -495,16 +495,6 @@ class DoxygenVariableDirective(DoxygenBaseItemDirective):
 
     kind = "variable"
 
-    def render(self, node_stack, project_info, options, filter_, target_handler, mask_factory):
-        # Remove 'extern' keyword as Sphinx doesn't support it.
-        definition = node_stack[0].definition
-        extern = 'extern '
-        if definition.startswith(extern):
-            definition = definition[len(extern):]
-        self.directive_args[1] = [definition]
-        return DoxygenBaseItemDirective.render(self, node_stack, project_info, options, filter_,
-                                               target_handler, mask_factory)
-
 
 class DoxygenDefineDirective(DoxygenBaseItemDirective):
 

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -42,6 +42,18 @@ Namespaced Function Examples
 .. doxygenfunction:: ClassTest::anotherFunction
    :path: ../../examples/specific/class/xml
 
+Extern Examples
+---------------
+
+.. cpp:namespace:: @ex_specific_extern_examples
+
+.. doxygenfunction:: cache_tree_matches_traversal
+   :project: c_file
+
+.. doxygenvariable:: global_cache_tree
+   :project: c_file
+
+
 Alias Example
 -------------
 


### PR DESCRIPTION
Add explicit example section for extern variables and functions, and remove now unneeded hax on varaibles.