### PR TITLE
Make debug config variables available in conf.py

### DIFF
--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -1,5 +1,6 @@
 from . import directives
 from . import file_state_cache
+from .renderer import sphinxrenderer
 
 from sphinx.application import Sphinx
 
@@ -9,6 +10,7 @@ __version__ = '4.18.1'
 def setup(app: Sphinx):
     directives.setup(app)
     file_state_cache.setup(app)
+    sphinxrenderer.setup(app)
 
     return {
         'version': __version__,

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -243,6 +243,10 @@ breathe_domain_by_file_pattern = {
 
 breathe_use_project_refids = True
 
+#breathe_debug_trace_directives = True
+#breathe_debug_trace_doxygen_ids = True
+#breathe_debug_trace_qualification = True
+
 
 # Options for HTML output
 # -----------------------

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -229,6 +229,9 @@ def render(app, member_def, domain=None, show_define_initializer=False):
 
     app.config.breathe_use_project_refids = False
     app.config.breathe_show_define_initializer = show_define_initializer
+    app.config.breathe_debug_trace_directives = False
+    app.config.breathe_debug_trace_doxygen_ids = False
+    app.config.breathe_debug_trace_qualification = False
     renderer = SphinxRenderer(app,
                               None,  # project_info
                               [],    # node_stack


### PR DESCRIPTION
In order to make debugging easier #512 added some variables for debug output. This PR makes them formal config variables so users can create more descriptive logs.

- ``breathe_debug_trace_directives = False``: the main variable that will print out the domain directives that Breathe runs, indented to indicate the scoping.
- ``breathe_debug_trace_doxygen_ids = False``: write some information about the Doxygen IDs that Breathe attaches to the declarations in order for inline references to be resolved. This can for example be used to get information for the remaining part of #356.
- ``breathe_debug_trace_qualification = False``: when a Breathe directive has found the entity to document, it may be nested somewhere inside the Doxygen XML. In order to construct the correct Sphinx directive it needs to figure out how the XML nesting translates into scope nesting. This variable prints out information about this process.