### PR TITLE
Fix warning formatting for function lookup

### DIFF
--- a/breathe/directive/base.py
+++ b/breathe/directive/base.py
@@ -13,41 +13,42 @@ from sphinx.directives import SphinxDirective
 from docutils import nodes
 from docutils.nodes import Node
 
-from typing import List
+from typing import Any, Dict, List, Optional, Sequence
 
 
 class WarningHandler:
-    def __init__(self, state, context):
+    def __init__(self, state, context: Dict[str, Any]) -> None:
         self.state = state
         self.context = context
 
-    def warn(self, raw_text, rendered_nodes=None):
-        raw_text = self.format(raw_text)
+    def warn(self, raw_text: str, *, rendered_nodes: Sequence[nodes.Node] = None,
+             unformatted_suffix: str = '') -> List[nodes.Node]:
+        raw_text = self.format(raw_text) + unformatted_suffix
         if rendered_nodes is None:
             rendered_nodes = [nodes.paragraph("", "", nodes.Text(raw_text))]
         return [
             nodes.warning("", *rendered_nodes),
             self.state.document.reporter.warning(raw_text, line=self.context['lineno'])
-            ]
+        ]
 
-    def format(self, text):
+    def format(self, text: str) -> str:
         return text.format(**self.context)
 
 
-def create_warning(project_info, state, lineno, **kwargs):
+def create_warning(project_info: Optional[ProjectInfo], state, lineno: int,
+                   **kwargs) -> WarningHandler:
     tail = ''
     if project_info:
         tail = 'in doxygen xml output for project "{project}" from directory: {path}'.format(
             project=project_info.name(),
             path=project_info.project_path()
-            )
+        )
 
     context = dict(
         lineno=lineno,
         tail=tail,
         **kwargs
-        )
-
+    )
     return WarningHandler(state, context)
 
 

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -105,29 +105,30 @@ class DoxygenFunctionDirective(BaseDirective):
                 '"{namespace}{function}" with arguments ({args}) {tail}.\n' \
                 'Potential matches:\n'
 
-            # We want to create a raw_text string for the console output and a set of docutils nodes
+            # We want to create a string for the console output and a set of docutils nodes
             # for rendering into the final output. We handle the final output as a literal string
             # with a txt based list of the options.
-            raw_text = message
             literal_text = ''
 
             # TODO: We're cheating here with the set() as signatures has repeating entries for some
             # reason (failures in the matcher_stack code) so we consolidate them by shoving them in
             # a set to remove duplicates. Should be fixed!
+            signatures = ''
             for i, entry in enumerate(sorted(set(error.signatures))):
                 if i:
                     literal_text += '\n'
                 # Replace new lines with a new line & enough spacing to reach the appropriate
                 # alignment for our simple plain text list
                 literal_text += '- %s' % entry.replace('\n', '\n  ')
-                raw_text += '    - %s\n' % entry.replace('\n', '\n      ')
+                signatures += '    - %s\n' % entry.replace('\n', '\n      ')
             block = nodes.literal_block('', '', nodes.Text(literal_text))
             formatted_message = warning.format(message)
             warning_nodes = [
                 nodes.paragraph("", "", nodes.Text(formatted_message)),
                 block
             ]
-            result = warning.warn(raw_text, warning_nodes)
+            result = warning.warn(message, rendered_nodes=warning_nodes,
+                                  unformatted_suffix=signatures)
             return result
 
         target_handler = create_target_handler(self.options, project_info, self.state.document)


### PR DESCRIPTION
Don't send raw signatures through the warning formatter as they may contain braces (e.g., as in https://github.com/michaeljones/breathe/issues/529#issuecomment-627219104).

Related to #529, but unclear to me if it fixes the reported issue.