### PR TITLE
Add support for innergroup

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -406,6 +406,10 @@ class DoxygenNamespaceDirective(_DoxygenContentBlockDirective):
 
 class DoxygenGroupDirective(_DoxygenContentBlockDirective):
     kind = "group"
+    option_spec = {
+        **_DoxygenContentBlockDirective.option_spec,
+        "inner": flag,
+    }
 
 
 # TODO: is this comment still relevant?

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1024,6 +1024,12 @@ class SphinxRenderer:
         addnode('innerclass', lambda: self.render_iterable(node.innerclass))
         addnode('innernamespace', lambda: self.render_iterable(node.innernamespace))
 
+        if 'inner' in options:
+            for node in node.innergroup:
+                file_data = self.compound_parser.parse(node.refid)
+                inner = file_data.compounddef
+                addnode('innergroup', lambda: self.visit_compounddef(inner))
+
         nodelist = []
         for i, nodes_ in sorted(nodemap.items()):
             nodelist += nodes_

--- a/documentation/source/group.rst
+++ b/documentation/source/group.rst
@@ -10,7 +10,7 @@ source comments as cover in the `doxygen documentation`_.
 
 It takes the standard ``project``, ``path``, ``outline`` and ``no-link`` options
 and additionally the ``content-only``, ``members``, ``protected-members``,
-``private-members`` and ``undoc-members`` options.
+``private-members``, ``undoc-members`` and ``inner`` options.
 
 ``content-only``
    If this flag is specified, then the directive does not output the name of the
@@ -41,6 +41,11 @@ If you would like to always specify some combination of ``members``,
 ``protected-members``, ``private-members`` and ``undoc-members`` then you can
 use the :ref:`breathe_default_members <breathe-default-members>` configuration
 variable to set it in the ``conf.py``.
+
+``inner``
+   If specified, the groups that were defined inside this group, by either
+   defining them inside the scope of another group, or by using the Doxygen
+   \ingroup command, are also parsed and loaded.
 
 .. _doxygen documentation: http://www.stack.nl/~dimitri/doxygen/manual/grouping.html
 
@@ -188,6 +193,27 @@ Produces this output:
 
    Undocumented classes are still not shown in the output due to an implementation
    issue. Please post an issue on github if you would like this resolved.
+
+
+Inner Example
+-------------
+
+.. cpp:namespace:: @ex_group_inner
+
+The ``inner`` option changes the output to include groups that are defined
+inside other groups.
+
+.. code-block:: rst
+
+   .. doxygengroup:: mygroup
+      :project: group
+      :inner:
+
+Produces this output:
+
+.. doxygengroup:: mygroup
+   :project: group
+   :inner:
 
 
 Outline Example

--- a/examples/specific/group.h
+++ b/examples/specific/group.h
@@ -48,6 +48,28 @@ void groupedFunction();
 
 /** @} */ // end of mygroup
 
+/** @defgroup innergroup Inner Group
+ *  @ingroup mygroup
+ *  This is an inner group
+ *  @{
+ */
+
+//! \brief inner class inside of namespace
+class InnerGroupClassTest {
+
+public:
+    //! \brief inner namespaced class function
+    void function() {};
+
+private:
+
+    //! A private function
+    void innerGroupPrivateFunction() {};
+
+    class PrivateClass {};
+};
+
+/** @} */ // end of innergroup
 
 //! \brief second class inside of namespace
 class UngroupedClassTest {


### PR DESCRIPTION
Doxygen groups that are defined inside another group, either by scope or by using \ingroup, are not automatically added to the documentation unless an explicit reference is created. This commit adds parsing of innergroup elements inside compound defs.

Fixes #555 