### PR TITLE
Add support for verbatim inline elements

### DIFF
--- a/breathe/process.py
+++ b/breathe/process.py
@@ -26,6 +26,7 @@ GENERATE_HTML = NO
 GENERATE_XML = YES
 ALIASES = "rst=\verbatim embed:rst"
 ALIASES += "endrst=\endverbatim"
+ALIASES += "inlinerst=\verbatim embed:rst:inline"
 {extra}
 """.strip()
 

--- a/documentation/source/markups.rst
+++ b/documentation/source/markups.rst
@@ -127,6 +127,38 @@ This will appropriately handle the leading slashes and render as:
 
 ----
 
+Inline rST
+~~~~~~~~~~
+
+.. cpp:namespace:: @ex_markups_inline
+
+Normal verbatim elements result in block elements. But sometimes you'll want
+to generate rST references where they need to be rendered inline with the text.
+For example::
+
+   /// Some kind of method
+   ///
+   /// @param something a parameter
+   /// @returns the same value provided in something param
+   ///
+   /// @verbatim embed:rst:inline some inline text @endverbatim
+
+For these kinds of references, you can use an **embed:rst:inline** tag as
+shown in the above example.
+
+This will appropriately handle the leading slashes and render as:
+
+----
+
+.. doxygenfunction:: TestClass::rawInlineVerbatim
+   :project: rst
+
+.. doxygenfunction:: TestClass::rawVerbatim
+   :project: rst
+   :outline:
+
+----
+
 Aliases
 ~~~~~~~
 

--- a/examples/specific/rst.cfg
+++ b/examples/specific/rst.cfg
@@ -12,3 +12,4 @@ GENERATE_XML = YES
 
 ALIASES = "rst=\verbatim embed:rst"
 ALIASES += "endrst=\endverbatim"
+ALIASES += "inlinerst=\verbatim embed:rst:inline"

--- a/examples/specific/rst.h
+++ b/examples/specific/rst.h
@@ -12,7 +12,7 @@ public:
     This is some funky non-XML compliant text: <& !><
 
     .. note::
-        
+
        This reStructuredText has been handled correctly.
     \endrst
 
@@ -66,6 +66,12 @@ public:
     /// @endverbatim
     //////////////////////////////////////////////////////////////
     virtual void rawLeadingSlashesVerbatim(int something) const = 0;
+
+    /*!
+    Inserting an inline reStructuredText snippet.
+    Linking to another function: \inlinerst :cpp:func:`TestClass::rawVerbatim` \endrst
+    */
+    virtual void rawInlineVerbatim() const = 0;
 
     //! Brief description
     virtual void testFunction() const {};


### PR DESCRIPTION
This extends the current verbatim rST support with a new option "embed:rst:inline", which can be used to generate an inline node, instead of the paragraph node used by other verbatim blocks.

For a bit of perspective, for the Zephyr project (https://docs.zephyrproject.org/) and for Nordic's nRF Connect SDK (http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html), we use the `.. option:` directive to create an entry for each existing configuration option in the kernel (and apps, libs, etc). For someone not acquainted this is very similar to configuration options in the Linux kernel (CONFIG_*).

We refer a lot to those options over all the documentation. In rST it is straight-forward to do using:

```
:option:`CONFIG<some_option_name>`
```
But in Doxygen headers the only way to get those xrefs working was to use a `\verbatim`, with the side-effect that it results in a `<paragraph \>` node, so it cannot be used inline.

This PR allows for one to specify an option by using:

```
\verbatim :embed:rst:inline :option:`CONFIG_<some_option_name>` \endverbatim
```
or by using a Doxygen alias:

```
ALIASES += "option{1}=\verbatim embed:rst:inline :option:`\1` \endverbatim"
```
 just `@option{CONFIG_<some_option_name>}`.