### PR TITLE
Allow Sphinx 3.2

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=3.0,<3.2
+Sphinx>=3.0,<3.3
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0,<3.2', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<3.3', 'docutils>=0.12', 'six>=1.9']
 
 if sys.version_info < (3, 5):
     print('ERROR: Sphinx requires at least Python 3.5 to run.')


### PR DESCRIPTION
The next minor version of Sphinx is schedule for next weekend (sphinx-doc/sphinx#8036). This allows it as a dependency.