### PR TITLE
Fix Read The Docs Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+python:
+  version: 3.5
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
With this configuration in place it seems to pass: https://readthedocs.org/projects/breathe/builds/

It seemed to previously be running with Python 2, I guess? Given that it was failing on annotations. https://readthedocs.org/projects/breathe/builds/11704046/

The config opts into the v2 settings for read the docs which seems to run Python 3 by default but we go further to set the Python version to 3.5 and ask it to install the dependences from setup.py.

I am very out of date with the Python ecosystem though so it might that there are better ways. Seems to work though. 

Though oddly, `https://breathe.readthedocs.io/en/readthedocs/` shows the old version with Sphinx 1.2.2 referenced at the bottom but appending `index.html` to the end (`https://breathe.readthedocs.io/en/readthedocs/index.html`) seems more up to date and references Sphinx 3.2.1. That said, I have no idea what the docs are meant to look like at the moment so maybe they're both different kinds of wrong. Not sure of the best way to resolve the `index.html` issue though. Well we can just make sure we link to that directly but it is a shame if that is necessary.