### PR TITLE
Update upper Sphinx release to <3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0,<3.3', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<3.4', 'docutils>=0.12', 'six>=1.9']
 
 if sys.version_info < (3, 5):
     print('ERROR: Sphinx requires at least Python 3.5 to run.')


### PR DESCRIPTION
When building the 3.x branch of Sphinx it generates a dev release on the 3.3 release number; this generates a warning when installing with Breathe due to the current <3.3 so bump it up to <3.4.