### PR TITLE
Add :inner: to the doxygengroup section

### DIFF
--- a/documentation/source/directives.rst
+++ b/documentation/source/directives.rst
@@ -211,6 +211,7 @@ and additionally the ``content-only``, ``members``, ``protected-members``,
       :private-members:
       :undoc-members:
       :no-link:
+      :inner:
 
 Checkout the :ref:`doxygengroup documentation <group-example>` for more details
 and to see it in action.


### PR DESCRIPTION
Leftover from PR #556; updated directives.rst to include :inner: