### PR TITLE
Fix anonymous struct/union usage in C domain

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1707,9 +1707,12 @@ class SphinxRenderer:
             if len(initializer) != 0:
                 options['value'] = initializer
         else:
+            typename = ''.join(n.astext() for n in self.render(node.get_type()))
+            if dom == 'c' and '::' in typename:
+                typename = typename.replace('::', '.')
             declaration = ' '.join([
                 self.create_template_prefix(node),
-                ''.join(n.astext() for n in self.render(node.get_type())),  # type: ignore
+                typename,
                 name,
                 node.get_argsstring(),
                 self.make_initializer(node)


### PR DESCRIPTION
Sphinx's C domain parser expects '.' to be used to separate nested names. This is currently broken when there are anonymous structs/unions in the source, where the Doxygen XML provides some nested name with "::@" in it, which  fails to be parsed properly. This commit adds a check and does the proper substitution before sending data back to the domain parser.