### PR TITLE
Add initial xrefsect support

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -1005,6 +1005,10 @@ class docParaTypeSub(supermod.docParaType):
             obj_ = supermod.docURLLink.factory()
             obj_.build(child_)
             self.content.append(obj_)
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "xrefsect":
+            obj_ = supermod.docXRefSectType.factory()
+            obj_.build(child_)
+            self.content.append(obj_)
 
 
 supermod.docParaType.subclass = docParaTypeSub

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1539,6 +1539,23 @@ class SphinxRenderer:
             ]
         return nodelist
 
+    def visit_docxrefsect(self, node) -> List[Node]:
+        signode = addnodes.desc_signature()
+        title = node.xreftitle[0] + ':'
+        titlenode = nodes.emphasis(text=title)
+        signode += titlenode
+
+        nodelist = self.render(node.xrefdescription)
+        contentnode = addnodes.desc_content()
+        contentnode += nodelist
+
+        descnode = addnodes.desc()
+        descnode['objtype'] = 'xrefsect'
+        descnode += signode
+        descnode += contentnode
+
+        return [descnode]
+
     def visit_mixedcontainer(self, node) -> List[Node]:
         return self.render_optional(node.getValue())
 
@@ -1913,7 +1930,8 @@ class SphinxRenderer:
         "docparamlistitem": visit_docparamlistitem,
         "docparamnamelist": visit_docparamnamelist,
         "docparamname": visit_docparamname,
-        "templateparamlist": visit_templateparamlist
+        "templateparamlist": visit_templateparamlist,
+        "docxrefsect": visit_docxrefsect,
     }
 
     def render(self, node, context: Optional[RenderContext] = None) -> List[Node]:

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -222,6 +222,7 @@ breathe_projects = {
     "cpp_friendclass":"../../examples/specific/cpp_friendclass/xml/",
     "cpp_inherited_members":"../../examples/specific/cpp_inherited_members/xml/",
     "cpp_trailing_return_type":"../../examples/specific/cpp_trailing_return_type/xml/",
+    "xrefsect": "../../examples/specific/xrefsect/xml/",
     }
 
 breathe_projects_source = {

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -10,10 +10,10 @@ Template Type Alias
 
 .. doxygentypedef:: IsFurry
    :path: ../../examples/specific/template_type_alias/xml
-      
+
 .. doxygentypedef:: IsFuzzy
    :path: ../../examples/specific/template_type_alias/xml
-      
+
 Typedef Examples
 ----------------
 
@@ -130,13 +130,13 @@ Array Parameter
 
 .. doxygenfunction:: bar
    :project: array
-   
+
 C Struct
 --------
 
 .. doxygenfile:: c_struct.h
    :project: c_struct
-   
+
 C Union
 -------
 
@@ -148,7 +148,7 @@ C Enum
 
 .. doxygenenum:: GSM_BackupFormat
    :project: c_enum
-   
+
 C Typedef
 ---------
 
@@ -166,7 +166,7 @@ C++ Macro
 
 .. doxygenfile:: define.h
    :project: define
-   
+
 Multifile
 ---------
 
@@ -190,7 +190,7 @@ C++ Anonymous Entities
 
 .. doxygenfile:: cpp_anon.h
    :project: cpp_anon
-   
+
 C++ Union
 ---------
 
@@ -238,3 +238,9 @@ C++ Trailing Return Type
 
 .. doxygenfile:: cpp_trailing_return_type.h
    :project: cpp_trailing_return_type
+
+Doxygen xrefsect
+----------------
+
+.. doxygenfile:: xrefsect.h
+   :project: xrefsect

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -23,7 +23,7 @@ projects  = nutshell alias rst inline namespacefile array inheritance \
 			image name union group struct struct_function qtsignalsandslots lists \
 			headings links parameters template_class template_class_non_type \
 			template_function template_type_alias template_specialisation \
-			enum define interface \
+			enum define interface xrefsect \
 			cpp_anon cpp_enum cpp_union cpp_function cpp_friendclass \
 			cpp_inherited_members cpp_trailing_return_type \
 			c_file c_struct c_enum c_typedef c_macro c_union

--- a/examples/specific/xrefsect.cfg
+++ b/examples/specific/xrefsect.cfg
@@ -1,0 +1,12 @@
+PROJECT_NAME     = "Doxygen xrefsect"
+OUTPUT_DIRECTORY = xrefsect
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = xrefsect.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES
+ALIASES = "xrefsample=\xrefitem xrefsample \"xref Sample\" \"xref Sample\" "

--- a/examples/specific/xrefsect.h
+++ b/examples/specific/xrefsect.h
@@ -1,0 +1,34 @@
+/**
+ *  @file xrefsect.h
+ *  A few examples of xrefsect items support.
+ */
+
+/**
+ * An example of using Doxygen's todo command.
+ *
+ * @todo Implement this function.
+ */
+int unimplemented(void);
+
+/**
+ * An example of using Doxygen's bug and test commands.
+ *
+ * @bug Does not work yet.
+ *
+ * @test Add proper unit testing first.
+ */
+void buggy_function(int param);
+
+/**
+ * An example of using Doxygen's deprecated command.
+ *
+ * @deprecated Should not be used on new code.
+ */
+void old_function(void);
+
+/**
+ * An example of a custom Doxygen xrefitem declared as an ALIAS.
+ *
+ * @xrefsample This text shows up in the xref output.
+ */
+void sample_xrefitem_function(void);


### PR DESCRIPTION
Add basic parsing support and rendering of xrefsect blocks. The current implementation does not generate links or any pages.

An xrefsect is generated when a @xrefitem keyword is found in Doxygen documentation, as well as the specialized forms like `\bug`, `\test` and `\deprecated`.

https://www.doxygen.nl/manual/commands.html#cmdxrefitem