### PR TITLE
Update xrefsect support

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -592,6 +592,7 @@ def setup(app: Sphinx) -> None:
     app.add_config_value("breathe_use_project_refids", False, "env")
     app.add_config_value("breathe_order_parameters_first", False, 'env')
     app.add_config_value("breathe_separate_member_pages", False, 'env')
+    app.add_config_value("breathe_xrefsect_into_env", False, 'env')
 
     breathe_css = "breathe.css"
     if (os.path.exists(os.path.join(app.confdir, "_static", breathe_css))):

--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -642,6 +642,12 @@ class docVarListEntryTypeSub(supermod.docVarListEntryType):
     def __init__(self, term=None):
         supermod.docVarListEntryType.__init__(self, term)
 
+    def buildChildren(self, child_, nodeName_):
+        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == 'term':
+            obj_ = supermod.docTitleType.factory()
+            obj_.build(child_)
+            self.set_term(obj_)
+
 
 supermod.docVarListEntryType.subclass = docVarListEntryTypeSub
 # end class docVarListEntryTypeSub
@@ -858,6 +864,33 @@ supermod.docXRefSectType.subclass = docXRefSectTypeSub
 # end class docXRefSectTypeSub
 
 
+class docVariableListTypeSub(supermod.docVariableListType):
+
+    node_type = "docvariablelist"
+
+    def __init__(self, valueOf_=''):
+        supermod.docVariableListType.__init__(self, valueOf_)
+
+        self.varlistentries = []
+        self.listitems = []
+
+    def buildChildren(self, child_, nodeName_):
+        supermod.docVariableListType.buildChildren(self, child_, nodeName_)
+
+        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "varlistentry":
+            obj_ = supermod.docVarListEntryType.factory()
+            obj_.build(child_)
+            self.varlistentries.append(obj_)
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "listitem":
+            obj_ = supermod.docListItemType.factory()
+            obj_.build(child_)
+            self.listitems.append(obj_)
+
+
+supermod.docVariableListType.subclass = docVariableListTypeSub
+# end class docVariableListTypeSub
+
+
 class docCopyTypeSub(supermod.docCopyType):
 
     node_type = "doccopy"
@@ -1009,6 +1042,10 @@ class docParaTypeSub(supermod.docParaType):
             obj_ = supermod.docXRefSectType.factory()
             obj_.build(child_)
             self.content.append(obj_)
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "variablelist":
+            obj_ = supermod.docVariableListType.factory()
+            obj_.build(child_)
+            self.content.append(obj_)
 
 
 supermod.docParaType.subclass = docParaTypeSub
@@ -1051,6 +1088,19 @@ class docTitleTypeSub(supermod.docTitleType):
     def __init__(self, valueOf_='', mixedclass_=None, content_=None):
         supermod.docTitleType.__init__(self, valueOf_, mixedclass_, content_)
         self.type_ = None
+
+    def buildChildren(self, child_, nodeName_):
+        supermod.docTitleType.buildChildren(self, child_, nodeName_)
+
+        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "ref":
+            obj_ = supermod.docRefTextType.factory()
+            obj_.build(child_)
+            self.content_.append(obj_)
+            self.valueOf_ += obj_.valueOf_
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "anchor":
+            obj_ = supermod.docAnchorType.factory()
+            obj_.build(child_)
+            self.content_.append(obj_)
 
 
 supermod.docTitleType.subclass = docTitleTypeSub

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1556,6 +1556,16 @@ class SphinxRenderer:
 
         return [descnode]
 
+    def visit_docvariablelist(self, node) -> List[Node]:
+        output = []
+        for varlistentry, listitem in zip(node.varlistentries, node.listitems):
+            output.extend(self.render_optional(varlistentry))
+            output.extend(self.render_optional(listitem))
+        return output
+
+    def visit_docvarlistentry(self, node) -> List[Node]:
+        return self.render_iterable(node.term.content_)
+
     def visit_mixedcontainer(self, node) -> List[Node]:
         return self.render_optional(node.getValue())
 
@@ -1932,6 +1942,8 @@ class SphinxRenderer:
         "docparamname": visit_docparamname,
         "templateparamlist": visit_templateparamlist,
         "docxrefsect": visit_docxrefsect,
+        "docvariablelist": visit_docvariablelist,
+        "docvarlistentry": visit_docvarlistentry,
     }
 
     def render(self, node, context: Optional[RenderContext] = None) -> List[Node]:

--- a/documentation/source/directives.rst
+++ b/documentation/source/directives.rst
@@ -552,3 +552,8 @@ Config Values
    to NO which generates XML that allows Breathe to resolve all references. When set
    to YES the refid/id of elements get an extra element which Breathe tries to get rid
    of when this setting is True.
+
+.. confval:: breathe_xrefsect_into_env
+
+   True or False setting to control if the parsing Doxygen xrefitems should populate
+   the env with data that can later be used to generate cross-reference pages.


### PR DESCRIPTION
This adds better parsing and rendering of xrefsect elements generated by Doxygen. It also optionally, via config option, populates a Sphinx environment dict with data that can later be used to generate the cross-reference pages. So this PR is basically an alternative to #590, where page generation was delegated to another extension.

Commits https://github.com/michaeljones/breathe/commit/15f5117d6e106c29847a8bb610b35c596a54892f and https://github.com/michaeljones/breathe/commit/def0c3b35e6d90f789c655b0553af8d04209d5ec should be fine already. Commit https://github.com/michaeljones/breathe/pull/593/commits/854ed42689df549246e42e4ce68faff5f150e5af is still WIP while I fix issues and redesign as required by the page generation extensions. For reference the page generation is currently here: https://github.com/utzig/zephyr/commit/c24e3a6e5f1b94249e346f80f356ee762586d6f1 (also WIP!).

@vermeeren Would like to hear on your thoughts!