### PR TITLE
Update to Sphinx 3.3.x branch and fix test mock

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
           - 3.0.4
           - 3.1.2
           - 3.2.0
-          - git+https://github.com/sphinx-doc/sphinx.git@3.2.x
+          - git+https://github.com/sphinx-doc/sphinx.git@3.3.x
           - git+https://github.com/sphinx-doc/sphinx.git@3.x
           # master (Sphinx 4) will require at least Python 3.6, so disable it for now
           #- git+https://github.com/sphinx-doc/sphinx.git@master

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -123,6 +123,8 @@ class MockStateMachine:
         self.reporter = MockReporter()
 
     def get_source_and_line(self, lineno: int):
+        if lineno is None:
+            lineno = 42
         return 'mock-doc', lineno
 
 


### PR DESCRIPTION
This avoids using Sphinx versions that are currently broken.