### PR TITLE
Fix anchors on pages generated by Doxygen>=1.8.17

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -1046,6 +1046,10 @@ class docParaTypeSub(supermod.docParaType):
             obj_ = supermod.docVariableListType.factory()
             obj_.build(child_)
             self.content.append(obj_)
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "anchor":
+            obj_ = supermod.docAnchorType.factory()
+            obj_.build(child_)
+            self.content.append(obj_)
 
 
 supermod.docParaType.subclass = docParaTypeSub


### PR DESCRIPTION
Doxygen has changed the structure of generated XML slightly since version 1.8.13 for "page" generation. Before it would put the anchor inside a `<varlistentry><term>` block, and on version 1.8.17 and newer, it inserts the anchor inside the matching `<listitem><para>`.

The `<variablelist>` block structure is still the same, so this commit only adds support for parsing anchors inside a `<para>` so it works on both XML generated by old and new versions of Doxygen.