### PR TITLE
parse multiple signatures

### DIFF
--- a/tests/data/memberdef.xml
+++ b/tests/data/memberdef.xml
@@ -1,0 +1,99 @@
+<sectiondef kind="typedef">
+<memberdef kind="function" id="1" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::Tensor::min_values</definition>
+  <argsstring>(IntArrayRef dim, bool keepdim=false) const</argsstring>
+  <name>min_values</name>
+  <param>
+    <type>IntArrayRef</type>
+    <declname>dim</declname>
+  </param>
+  <param>
+    <type>bool</type>
+    <declname>keepdim</declname>
+    <defval>false</defval>
+  </param>
+  <briefdescription>
+  </briefdescription>
+  <detaileddescription>
+  </detaileddescription>
+  <inbodydescription>
+  </inbodydescription>
+  <location file="TensorBody.h" line="736" column="10"/>
+</memberdef>
+<memberdef kind="function" id="2" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::Tensor::min_values</definition>
+  <argsstring>(DimnameList dim, bool keepdim=false) const</argsstring>
+  <name>min_values</name>
+  <param>
+    <type>DimnameList</type>
+    <declname>dim</declname>
+  </param>
+  <param>
+    <type>bool</type>
+    <declname>keepdim</declname>
+    <defval>false</defval>
+  </param>
+  <briefdescription>
+  </briefdescription>
+  <detaileddescription>
+  </detaileddescription>
+  <inbodydescription>
+  </inbodydescription>
+  <location file="TensorBody.h" line="738" column="10"/>
+</memberdef>
+<memberdef kind="function" id="3" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::min_values</definition>
+  <argsstring>(const Tensor &amp;self, IntArrayRef dim, bool keepdim=false)</argsstring>
+  <name>min_values</name>
+  <param>
+    <type>const <ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref> &amp;</type>
+    <declname>self</declname>
+  </param>
+  <param>
+    <type>IntArrayRef</type>
+    <declname>dim</declname>
+  </param>
+  <param>
+    <type>bool</type>
+    <declname>keepdim</declname>
+    <defval>false</defval>
+  </param>
+  <briefdescription>
+  </briefdescription>
+  <detaileddescription>
+  </detaileddescription>
+  <inbodydescription>
+  </inbodydescription>
+  <location file="Functions.h" line="441" column="15" declfile="Functions.h" declline="441" declcolumn="15"/>
+</memberdef>
+<memberdef kind="function" id="4" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::min_values</definition>
+  <argsstring>(const Tensor &amp;self, DimnameList dim, bool keepdim=false)</argsstring>
+  <name>min_values</name>
+  <param>
+    <type>const <ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref> &amp;</type>
+    <declname>self</declname>
+  </param>
+  <param>
+    <type>DimnameList</type>
+    <declname>dim</declname>
+  </param>
+  <param>
+    <type>bool</type>
+    <declname>keepdim</declname>
+    <defval>false</defval>
+  </param>
+  <briefdescription>
+  </briefdescription>
+  <detaileddescription>
+  </detaileddescription>
+  <inbodydescription>
+  </inbodydescription>
+  <location file="Functions.h" line="444" column="15" declfile="Functions.h" declline="444" declcolumn="15"/>
+</memberdef>
+</sectiondef>
+


### PR DESCRIPTION
Related to gh-604, gh-289, gh-504, gh-529
and motivated by pytorch/pytorch#47462

I have added a test that demonstrates the problem, focused on `DoxygenFunctionDirective.resolve_function`. The test is taken from the 4 declarations of pytorch declarations of `at::Tensor::min_values`. It fails to pass. I think there are two problems:
- the `NoParameterNamesMask` (if I understand its purpose correctly) is not stripping off the parameter names.
- the function declares parameters like `const Tensor &self`, but the arg passed to `resolve_function` is `const Tensor&` without a space between the type and the ampersand.

Any thoughts what to do to fix this? Feel free to push to my branch or give me any guidance.