### PR TITLE
Allow lookup in doxygenfunction without writing param names

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -152,6 +152,7 @@ class DoxygenFunctionDirective(BaseDirective):
                 declarator = declarator.next
             assert hasattr(declarator, 'declId')
             declarator.declId = None
+            p.arg.init = None
         return paramQual
 
     def create_function_signature(self, node_stack, project_info, filter_, target_handler,
@@ -221,14 +222,15 @@ class DoxygenFunctionDirective(BaseDirective):
             signatures.append(signature)
 
             match = re.match(r"([^(]*)(.*)", signature)
-            match_args = match.group(2)
+            _match_args = match.group(2)
 
             # Parse the text to find the arguments
-            match_args = self.parse_args(match_args)
+            match_args = self.parse_args(_match_args)
 
             # Match them against the arg spec
             if args == match_args:
                 return entry
+
         raise UnableToResolveFunctionError(signatures)
 
 

--- a/tests/data/arange.xml
+++ b/tests/data/arange.xml
@@ -1,0 +1,149 @@
+<sectiondef kind="typedef">
+<memberdef kind="function" id="1" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar end, const TensorOptions &amp;options={})</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>const TensorOptions &amp;</type>
+    <declname>options</declname>
+    <defval>{}</defval>
+  </param>
+</memberdef>
+<memberdef kind="function" id="2" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar end, c10::optional&lt; ScalarType &gt; dtype, c10::optional&lt; Layout &gt; layout, c10::optional&lt; Device &gt; device, c10::optional&lt; bool &gt; pin_memory)</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; ScalarType &gt;</type>
+    <declname>dtype</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Layout &gt;</type>
+    <declname>layout</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Device &gt;</type>
+    <declname>device</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; bool &gt;</type>
+    <declname>pin_memory</declname>
+  </param>
+</memberdef>
+<memberdef kind="function" id="3" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, const TensorOptions &amp;options={})</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>const TensorOptions &amp;</type>
+    <declname>options</declname>
+    <defval>{}</defval>
+  </param>
+</memberdef>
+<memberdef kind="function" id="4" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, c10::optional&lt; ScalarType &gt; dtype, c10::optional&lt; Layout &gt; layout, c10::optional&lt; Device &gt; device, c10::optional&lt; bool &gt; pin_memory)</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; ScalarType &gt;</type>
+    <declname>dtype</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Layout &gt;</type>
+    <declname>layout</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Device &gt;</type>
+    <declname>device</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; bool &gt;</type>
+    <declname>pin_memory</declname>
+  </param>
+</memberdef>
+<memberdef kind="function" id="5" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, Scalar step, const TensorOptions &amp;options={})</argsstring>
+  <name>range</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>step</declname>
+  </param>
+  <param>
+    <type>const TensorOptions &amp;</type>
+    <declname>options</declname>
+    <defval>{}</defval>
+  </param>
+</memberdef>
+<memberdef kind="function" id="6" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, Scalar step, c10::optional&lt; ScalarType &gt; dtype, c10::optional&lt; Layout &gt; layout, c10::optional&lt; Device &gt; device, c10::optional&lt; bool &gt; pin_memory)</argsstring>
+  <name>range</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>step</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; ScalarType &gt;</type>
+    <declname>dtype</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Layout &gt;</type>
+    <declname>layout</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Device &gt;</type>
+    <declname>device</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; bool &gt;</type>
+    <declname>pin_memory</declname>
+  </param>
+</memberdef>
+</sectiondef>


### PR DESCRIPTION
When using ``doxygenfunction`` one can either write a (qualified) name, or a (qualified) name with a function parameter list. PR #512 broke the functionality where one can omit the parameter names and still get a correct lookup.
This PR uses the parsing in the Sphinx C++ domain such that function qualifiers, trailing return types, etc. will be parsed. During lookup all parameter names are erased to ensure that only overloadable information is left for comparison.
Note, this does not fix issues where a template parameter list is needed for resolution (https://github.com/michaeljones/breathe/issues/289#issuecomment-623098080).
As the old code, the directive still assumes that qualified names and function parameters are only used with C++ declarations (https://github.com/michaeljones/breathe/issues/289#issuecomment-628858783).

The PR is an alternative to michaeljones/breathe#605, but I have only done superficial testing with the Breathe docs.