### PR TITLE
add test for ellipsis in args

### DIFF
--- a/tests/data/ellipsis.xml
+++ b/tests/data/ellipsis.xml
@@ -1,0 +1,20 @@
+<sectiondef kind="typedef">
+<memberdef kind="function" id="0" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type>double</type>
+  <definition>double amici::spline_pos</definition>
+  <argsstring>(double t, int num,...)</argsstring>
+  <name>spline_pos</name>
+  <param>
+    <type>double</type>
+    <declname>t</declname>
+  </param>
+  <param>
+    <type>int</type>
+    <declname>num</declname>
+  </param>
+  <param>
+    <type>...</type>
+  </param>
+</memberdef>
+</sectiondef>
+


### PR DESCRIPTION
xref [this comment](https://github.com/michaeljones/breathe/issues/608#issuecomment-746289597) asking for a test for gh-609: here is a test that fails before, and passes after the fix in gh-609.

Since there are now two tests that parse XML, I refactored the common parts out into helper functions. Feel free to fix up as you see fit.