### PR TITLE
Sphinx 3.4.x compatibility

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,12 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         sphinx-version:
           - 3.0.4
           - 3.1.2
-          - 3.2.0
-          - git+https://github.com/sphinx-doc/sphinx.git@3.3.x
+          - 3.2.1
+          - 3.3.1
+          - 3.4.3
+          - git+https://github.com/sphinx-doc/sphinx.git@3.4.x
           - git+https://github.com/sphinx-doc/sphinx.git@3.x
           # master (Sphinx 4) will require at least Python 3.6, so disable it for now
           #- git+https://github.com/sphinx-doc/sphinx.git@master

--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -589,7 +589,7 @@ def setup(app: Sphinx) -> None:
     app.add_config_value("breathe_separate_member_pages", False, 'env')
 
     breathe_css = "breathe.css"
-    if (os.path.exists(os.path.join(app.confdir, "_static", breathe_css))):
+    if (os.path.exists(os.path.join(app.confdir, "_static", breathe_css))):  # type: ignore
         app.add_stylesheet(breathe_css)
 
     def write_file(directory, filename, content):

--- a/breathe/path_handler.py
+++ b/breathe/path_handler.py
@@ -15,4 +15,4 @@ def resolve_path(app: Sphinx, directory: str, filename: str):
     """
 
     # os.path.join does the appropriate handling if _project_path is an absolute path
-    return os.path.join(app.confdir, directory, filename)
+    return os.path.join(app.confdir, directory, filename)  # type: ignore

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=3.0,<3.4
+Sphinx>=3.0,<3.5
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0,<3.4', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<3.5', 'docutils>=0.12', 'six>=1.9']
 
 if sys.version_info < (3, 5):
     print('ERROR: Sphinx requires at least Python 3.5 to run.')


### PR DESCRIPTION
Allows for running on 3.4.x series, and updates test matrix to add Python 3.9.0 and all minor Sphinx releases in the 3.x series as well as the development tag.

This fixes #612 and supersedes #615

@vermeeren I would suggest releasing 4.26.0 if possible.