### PR TITLE
Adapt friendclass to Doxygen 1.9

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1781,7 +1781,11 @@ class SphinxRenderer:
         desc += signode
 
         typ = ''.join(n.astext() for n in self.render(node.get_type()))  # type: ignore
-        assert typ in ("friend class", "friend struct")
+        # in Doxygen < 1.9 the 'friend' part is there, but afterwards not
+        # https://github.com/michaeljones/breathe/issues/616
+        assert typ in ("friend class", "friend struct", "class", "struct")
+        if not typ.startswith('friend '):
+            typ = 'friend ' + typ
         signode += addnodes.desc_annotation(typ, typ)
         signode += nodes.Text(' ')
         # expr = cpp.CPPExprRole(asCode=False)


### PR DESCRIPTION
From Doxygen 1.9.0 the XML for friend class declarations has changed, e.g.,::
```diff
       <memberdef kind="friend" id="classBar_1a549e901751cbd1b0dd39326270e23ca6" prot="private" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
-        <type>friend class</type>
+        <type>class</type>
         <definition>friend class Foo</definition>
         <argsstring></argsstring>
         <name>Foo</name>
+        <param>
+          <type><ref refid="classFoo" kindref="compound">Foo</ref></type>
+        </param>
         <briefdescription>
         </briefdescription>
         <detaileddescription>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
         <location file="foo.h" line="6" column="5" bodyfile="foo.h" bodystart="6" bodyend="-1"/>
       </memberdef>
```

Fixes #616.