### PR TITLE
doxygenfunction fixes

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -28,7 +28,7 @@ import os
 import re
 import subprocess
 
-from typing import Any, List, Type  # noqa
+from typing import Any, List, Optional, Type  # noqa
 
 
 class NoMatchingFunctionError(BreatheError):
@@ -76,7 +76,7 @@ class DoxygenFunctionDirective(BaseDirective):
             return warning.warn('doxygenfunction: %s' % e)
 
         # Extract arguments from the function name.
-        args = self.parse_args(args)
+        args = self._parse_args(args)
 
         finder_filter = self.filter_factory.create_function_finder_filter(namespace, function_name)
 
@@ -96,13 +96,13 @@ class DoxygenFunctionDirective(BaseDirective):
             )
 
         try:
-            node_stack = self.resolve_function(matches, args, project_info)
+            node_stack = self._resolve_function(matches, args, project_info)
         except NoMatchingFunctionError:
             return warning.warn('doxygenfunction: Cannot find function "{namespace}{function}" '
                                 '{tail}')
         except UnableToResolveFunctionError as error:
-            message = 'doxygenfunction: Unable to resolve multiple matches for function ' \
-                '"{namespace}{function}" with arguments ({args}) {tail}.\n' \
+            message = 'doxygenfunction: Unable to resolve function ' \
+                '"{namespace}{function}" with arguments {args} {tail}.\n' \
                 'Potential matches:\n'
 
             # We want to create a string for the console output and a set of docutils nodes
@@ -137,9 +137,9 @@ class DoxygenFunctionDirective(BaseDirective):
         return self.render(node_stack, project_info, filter_, target_handler, NullMaskFactory(),
                            self.directive_args)
 
-    def parse_args(self, function_description):
+    def _parse_args(self, function_description: str) -> Optional[cpp.ASTParametersQualifiers]:
         if function_description == '':
-            function_description = '()'
+            return None
 
         parser = cpp.DefinitionParser(function_description,
                                       location=self.get_source_info(),
@@ -152,14 +152,14 @@ class DoxygenFunctionDirective(BaseDirective):
                 continue
             declarator = p.arg.type.decl
             while hasattr(declarator, 'next'):
-                declarator = declarator.next
+                declarator = declarator.next  # type: ignore
             assert hasattr(declarator, 'declId')
-            declarator.declId = None
-            p.arg.init = None
+            declarator.declId = None  # type: ignore
+            p.arg.init = None  # type: ignore
         return paramQual
 
-    def create_function_signature(self, node_stack, project_info, filter_, target_handler,
-                                  mask_factory, directive_args):
+    def _create_function_signature(self, node_stack, project_info, filter_, target_handler,
+                                   mask_factory, directive_args) -> str:
         "Standard render process used by subclasses"
 
         try:
@@ -177,7 +177,8 @@ class DoxygenFunctionDirective(BaseDirective):
             return format_parser_error("doxygenclass", e.error, e.filename, self.state,
                                        self.lineno, True)
         except FileIOError as e:
-            return format_parser_error("doxygenclass", e.error, e.filename, self.state, self.lineno)
+            return format_parser_error("doxygenclass", e.error, e.filename, self.state,
+                                       self.lineno, False)
 
         context = RenderContext(node_stack, mask_factory, directive_args)
         node = node_stack[0]
@@ -197,16 +198,12 @@ class DoxygenFunctionDirective(BaseDirective):
         ast = parser.parse_declaration('function', 'function')
         return str(ast)
 
-    def resolve_function(self, matches, args, project_info):
+    def _resolve_function(self, matches, args: Optional[cpp.ASTParametersQualifiers], project_info):
         if not matches:
             raise NoMatchingFunctionError()
 
-        if len(matches) == 1:
-            return matches[0]
-
-        signatures = []
-
-        # Iterate over the potential matches
+        res = []
+        candSignatures = []
         for entry in matches:
             text_options = {'no-link': u'', 'outline': u''}
 
@@ -220,21 +217,28 @@ class DoxygenFunctionDirective(BaseDirective):
             directive_args = self.directive_args[:]
             directive_args[2] = text_options
 
-            signature = self.create_function_signature(entry, project_info, filter_, target_handler,
-                                                       mask_factory, directive_args)
-            signatures.append(signature)
+            signature = self._create_function_signature(entry, project_info, filter_, target_handler,
+                                                        mask_factory, directive_args)
+            candSignatures.append(signature)
 
-            match = re.match(r"([^(]*)(.*)", signature)
-            _match_args = match.group(2)
+            if args is not None:
+                match = re.match(r"([^(]*)(.*)", signature)
+                assert match
+                _match_args = match.group(2)
 
-            # Parse the text to find the arguments
-            match_args = self.parse_args(_match_args)
+                # Parse the text to find the arguments
+                match_args = self._parse_args(_match_args)
 
-            # Match them against the arg spec
-            if args == match_args:
-                return entry
+                # Match them against the arg spec
+                if args != match_args:
+                    continue
 
-        raise UnableToResolveFunctionError(signatures)
+            res.append((entry, signature))
+
+        if len(res) == 1:
+            return res[0][0]
+        else:
+            raise UnableToResolveFunctionError(candSignatures)
 
 
 class _DoxygenClassLikeDirective(BaseDirective):

--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -1026,16 +1026,17 @@ class FilterFactory:
             return (parent_is_compound & parent_is_file & node_matches) \
                 | (parent_is_compound & parent_is_not_file & node_matches)
 
-    def create_function_finder_filter(self, namespace: str, name: str) -> Filter:
+    def create_function_and_all_friend_finder_filter(self, namespace: str, name: str) -> Filter:
         parent = Parent()
         parent_is_compound = parent.node_type == 'compound'
         parent_is_group = parent.kind == 'group'
 
         function_filter = self.create_member_finder_filter(namespace, name, 'function')
+        friend_filter = self.create_member_finder_filter(namespace, name, 'friend')
         # Get matching functions but only ones where the parent is not a group. We want to skip
         # function entries in groups as we'll find the same functions in a file's xml output
         # elsewhere and having more than one match is confusing for our logic later on.
-        return function_filter & ~(parent_is_compound & parent_is_group)
+        return (function_filter | friend_filter) & ~(parent_is_compound & parent_is_group)
 
     def create_enumvalue_finder_filter(self, name: str) -> Filter:
         """Returns a filter which looks for an enumvalue with the specified name."""

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1606,12 +1606,14 @@ class SphinxRenderer:
             if dom == 'py':
                 declaration = name + node.get_argsstring()
             else:
-                declaration = ' '.join([
-                    self.create_template_prefix(node),
-                    ''.join(n.astext() for n in self.render(node.get_type())),  # type: ignore
-                    name,
-                    node.get_argsstring()
-                ])
+                elements = [self.create_template_prefix(node)]
+                if node.kind == 'friend':
+                    elements.append('friend')
+                elements.append(''.join(n.astext()
+                                        for n in self.render(node.get_type())))  # type: ignore
+                elements.append(name)
+                elements.append(node.get_argsstring())
+                declaration = ' '.join(elements)
             nodes = self.handle_declaration(node, declaration)
             return nodes
         else:

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -457,14 +457,14 @@ def test_resolve_overrides(app):
 
     # Verify that the exact arguments returns one override
     for args in argsstrings:
-        ast_param = cls.parse_args(args)
-        ret = cls.resolve_function(matches, ast_param, None)
+        ast_param = cls._parse_args(args)
+        ret = cls._resolve_function(matches, ast_param, None)
 
 def test_ellipsis(app):
     argsstrings, matches = get_matches('ellipsis.xml')
     cls = get_directive(app)
 
     # Verify that parsing an ellipsis works
-    ast_param = cls.parse_args(argsstrings[0])
-    ret = cls.resolve_function(matches, ast_param, None)
+    ast_param = cls._parse_args(argsstrings[0])
+    ret = cls._resolve_function(matches, ast_param, None)
 


### PR DESCRIPTION
Three fixes:
1. Render the ``friend`` keyword in friend functions.
2. Fix #613.
   In the Doxygen XML a friend function does not have ``function`` as ``kind``, but ``friend``. Unfortunately so does a friend class. One way to distinguish between them is then to check emptiness of the ``argsstring``.
   E.g., for
   ```c++
   struct D {
           friend class A;
           friend D operator+();
   };
   ```
   the xml for the content of ``D`` is then
   ```xml
   <memberdef kind="friend" id="structD_1a3c84b3381e0c864a7415d891b6a053ba" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
      <type>class</type>
      <definition>friend class A</definition>
      <argsstring></argsstring>
      <name>A</name>
      <param>
         <type><ref refid="structA" kindref="compound">A</ref></type>
      </param>
      ...
   </memberdef>
   <memberdef kind="friend" id="structD_1a35b414831ab33977d59b0e2959c354b4" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
      <type><ref refid="structD" kindref="compound">D</ref></type>
       <definition>D operator+</definition>
       <argsstring>()</argsstring>
       <name>operator+</name>
       ...
   </memberdef>
   ```
   However, when searching the XML the filters (e.g., https://github.com/michaeljones/breathe/blob/v4.26.0/breathe/renderer/filter.py#L1001) do not search in this XML, but in ``index.xml`` which has
   ```xml
   <member refid="structD_1a3c84b3381e0c864a7415d891b6a053ba" kind="friend"><name>A</name></member>
   <member refid="structD_1a35b414831ab33977d59b0e2959c354b4" kind="friend"><name>operator+</name></member>
   ```
   and then those index nodes are converted to the corresponding content nodes at some point before they come out at https://github.com/michaeljones/breathe/blob/v4.26.0/breathe/directives.py#L85.
   The filtering of friends is thus done in the directive instead of in the filter.
3. Strengthen check on arguments when there is only one candidate.
   Consider the C++
   ```c++
   void f(int);
   ```
   and the rst
   ```rst
   .. doxygenfunction:: f(int, double, std::string)
   ```
   This previously succeeded. Now, if parameters are given in the directive, they are always checked for each candidate. The example will now given a lookup warning.

In addition I removed the deduplication of candidates in the lookup warning. I'm not sure when it makes a difference, but it is only in the output, and is more in line with the internal check. Would be good to see an example where duplicates appear.