### PR TITLE
Initial support for table rendering

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -1054,6 +1054,10 @@ class docParaTypeSub(supermod.docParaType):
             obj_ = supermod.docParBlockType.factory()
             obj_.build(child_)
             self.content.append(obj_)
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "table":
+            obj_ = supermod.docTableType.factory()
+            obj_.build(child_)
+            self.content.append(obj_)
 
 
 supermod.docParaType.subclass = docParaTypeSub


### PR DESCRIPTION
This adds basic support to table rendering. Tables generates using Markdown syntax or <table> both generate a similar Doxygen so both can be used in documentation.

https://www.doxygen.nl/manual/tables.html
https://www.doxygen.nl/manual/markdown.html#md_tables

Some features are still missing, like colspan, rowspan and alignment. Those are not available in the Doxygen XML generated by versions <=1.8.17. Doxygen XML generated by Doxygen 1.9.1 works correctly. When using those features the current implementation will just output blank rows or cols, rendering improperly, but without exceptions.

Fixes #629