### PR TITLE
Add rendering of \section, \subsection and \subsubsection

### DIFF
--- a/breathe/parser/compoundsuper.py
+++ b/breathe/parser/compoundsuper.py
@@ -2888,6 +2888,10 @@ class docSect1Type(GeneratedsSuper):
             self.content_ = []
         else:
             self.content_ = content_
+        if title is None:
+            self.title = ""
+        else:
+            self.title = title
     def factory(*args_, **kwargs_):
         if docSect1Type.subclass:
             return docSect1Type.subclass(*args_, **kwargs_)
@@ -2943,11 +2947,7 @@ class docSect1Type(GeneratedsSuper):
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'title':
-            childobj_ = docTitleType.factory()
-            childobj_.build(child_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'title', childobj_)
-            self.content_.append(obj_)
+            self.title = child_.childNodes[0].nodeValue
         elif child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'para':
             childobj_ = docParaType.factory()
@@ -2989,6 +2989,10 @@ class docSect2Type(GeneratedsSuper):
             self.content_ = []
         else:
             self.content_ = content_
+        if title is None:
+            title = ""
+        else:
+            title = title
     def factory(*args_, **kwargs_):
         if docSect2Type.subclass:
             return docSect2Type.subclass(*args_, **kwargs_)
@@ -3044,11 +3048,7 @@ class docSect2Type(GeneratedsSuper):
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'title':
-            childobj_ = docTitleType.factory()
-            childobj_.build(child_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'title', childobj_)
-            self.content_.append(obj_)
+            self.title = child_.childNodes[0].nodeValue
         elif child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'para':
             childobj_ = docParaType.factory()
@@ -3090,6 +3090,10 @@ class docSect3Type(GeneratedsSuper):
             self.content_ = []
         else:
             self.content_ = content_
+        if title is None:
+            self.title = ""
+        else:
+            self.title = title
     def factory(*args_, **kwargs_):
         if docSect3Type.subclass:
             return docSect3Type.subclass(*args_, **kwargs_)
@@ -3145,11 +3149,7 @@ class docSect3Type(GeneratedsSuper):
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'title':
-            childobj_ = docTitleType.factory()
-            childobj_.build(child_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'title', childobj_)
-            self.content_.append(obj_)
+            self.title = child_.childNodes[0].nodeValue
         elif child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'para':
             childobj_ = docParaType.factory()

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1344,8 +1344,19 @@ class SphinxRenderer:
             print("Warning: does not currently handle 'small' text display")
         return [creator("", "", *nodelist)]
 
-    def visit_docsect1(self, node) -> List[Node]:
-        return []
+    def visit_docsectN(self, node) -> List[Node]:
+        '''
+        Docutils titles are defined by their level inside the document so
+        the proper structure is only guaranteed by the Doxygen XML.
+
+        Doxygen command mapping to XML element name:
+        @section == sect1, @subsection == sect2, @subsubsection == sect3
+        '''
+        section = nodes.section()
+        section['ids'].append(node.id)
+        section += nodes.title(node.title, node.title)
+        section += self.render_iterable(node.content_)
+        return [section]
 
     def visit_docsimplesect(self, node) -> List[Node]:
         """Other Type documentation such as Warning, Note, Returns, etc"""
@@ -1986,7 +1997,9 @@ class SphinxRenderer:
         "docimage": visit_docimage,
         "docurllink": visit_docurllink,
         "docmarkup": visit_docmarkup,
-        "docsect1": visit_docsect1,
+        "docsect1": visit_docsectN,
+        "docsect2": visit_docsectN,
+        "docsect3": visit_docsectN,
         "docsimplesect": visit_docsimplesect,
         "doctitle": visit_doctitle,
         "docformula": visit_docformula,


### PR DESCRIPTION
 \section, \subsection and \subsubsection are commands that can be added to \page for creating multi-level section rendering, including a title and content.
    
https://www.doxygen.nl/manual/commands.html#cmdsection
https://www.doxygen.nl/manual/commands.html#cmdsubsection
https://www.doxygen.nl/manual/commands.html#cmdsubsubsection
    
Implement the rendering using Docutils nodes.title() which already uses the structure of the document to attribute a proper heading level, which should not need extra handling since the Doxygen XML already guarantees the proper structure.