### PR TITLE
Sphinx 3.5 compatibility

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,8 @@ jobs:
           - 3.2.1
           - 3.3.1
           - 3.4.3
-          - git+https://github.com/sphinx-doc/sphinx.git@3.4.x
+          - 3.5.0
+          - git+https://github.com/sphinx-doc/sphinx.git@3.5.x
           - git+https://github.com/sphinx-doc/sphinx.git@3.x
           # master (Sphinx 4) will require at least Python 3.6, so disable it for now
           #- git+https://github.com/sphinx-doc/sphinx.git@master

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=3.0,<3.5
+Sphinx>=3.0,<3.6
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0,<3.5', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<3.6', 'docutils>=0.12', 'six>=1.9']
 
 if sys.version_info < (3, 5):
     print('ERROR: Sphinx requires at least Python 3.5 to run.')


### PR DESCRIPTION
* Allow working with newer Sphinx 3.5.0
* Add Sphinx 3.5.0 and change 3.4.x branch to 3.5.x in unit tests matrix. This should fix the broken CI.

This should fix the failures seen on #638 and #639