### PR TITLE
Add support for content-only flag when rendering pages 

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -347,12 +347,11 @@ class _DoxygenContentBlockDirective(BaseDirective):
                                      kind=self.kind)
             return warning.warn('doxygen{kind}: Cannot find {kind} "{name}" {tail}')
 
-        if 'content-only' in self.options:
+        if 'content-only' in self.options and self.kind != "page":
             # Unpack the single entry in the matches list
             (node_stack,) = matches
 
             filter_ = self.filter_factory.create_content_filter(self.kind, self.options)
-
             # Having found the compound node for the namespace or group in the index we want to grab
             # the contents of it which match the filter
             contents_finder = self.finder_factory.create_finder_from_root(node_stack[0],
@@ -404,6 +403,7 @@ class DoxygenPageDirective(_DoxygenContentBlockDirective):
     option_spec = {
         "path": unchanged_required,
         "project": unchanged_required,
+        "content-only": flag,
     }
 
 

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1087,25 +1087,34 @@ class SphinxRenderer:
 
     def visit_file(self, node) -> List[Node]:
         def render_signature(file_data, doxygen_target, name, kind):
-            # Build targets for linking
-            targets = []
-            targets.extend(doxygen_target)
+            self.context = cast(RenderContext, self.context)
+            options = self.context.directive_args[2]
 
-            title_signode = addnodes.desc_signature()
-            title_signode.extend(targets)
+            if "content-only" in options:
+                rst_node = nodes.container()
+            else:
+                rst_node = addnodes.desc()
 
-            # Set up the title
-            title_signode.append(nodes.emphasis(text=kind))
-            title_signode.append(nodes.Text(" "))
-            title_signode.append(addnodes.desc_name(text=name))
+                # Build targets for linking
+                targets = []
+                targets.extend(doxygen_target)
 
-            contentnode = addnodes.desc_content()
+                title_signode = addnodes.desc_signature()
+                title_signode.extend(targets)
 
-            rst_node = addnodes.desc()
+                # Set up the title
+                title_signode.append(nodes.emphasis(text=kind))
+                title_signode.append(nodes.Text(" "))
+                title_signode.append(addnodes.desc_name(text=name))
+
+                rst_node.append(title_signode)
+
             rst_node.document = self.state.document
             rst_node['objtype'] = kind
-            rst_node.append(title_signode)
+
+            contentnode = addnodes.desc_content()
             rst_node.append(contentnode)
+
             return [rst_node], contentnode
         return self.visit_compound(node, render_signature=render_signature)
 

--- a/documentation/source/directives.rst
+++ b/documentation/source/directives.rst
@@ -396,13 +396,15 @@ page. A doxygen page is created for each "key" of every \\xrefitem command used
 for markup in the source comments. For more information check the
 `doxygen xrefitem documentation`_.
 
-It takes the standard ``project`` and ``path`` options.
+It takes the standard ``project`` and ``path`` options and additionally the
+``content-only`` option.
 
 ::
 
    .. doxygenpage:: <page name>
       :project: ...
       :path: ...
+      :content-only:
 
 Checkout the :ref:`doxygenpage documentation <page-example>` for more details
 and to see it in action.


### PR DESCRIPTION
Support for pages was added in https://github.com/michaeljones/breathe/pull/596. This PR adds support for the `content-only` flag when rendering pages, so that when creating an rst file with only

```
.. doxygenpage: test
    :content-only:
```

the entire page is rendered as if it was a native rst page.

Note that this is my first contribution to breathe, so expect a non-optimal/wrong solution. Suggestions are welcome :-)

