### PR TITLE
When rendering a section, add target after title

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1354,8 +1354,8 @@ class SphinxRenderer:
         '''
         section = nodes.section()
         section['ids'].append(self.get_refid(node.id))
-        section += self.create_doxygen_target(node)
         section += nodes.title(node.title, node.title)
+        section += self.create_doxygen_target(node)
         section += self.render_iterable(node.content_)
         return [section]
 


### PR DESCRIPTION
Sphinx's TOC renderer doesn't seem to like adding a target before a title in a section, so just swap the ordering in which the nodes are added; this should not affect the rendering itself.

Fixes #646