### PR TITLE
Render pages content in order

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -968,6 +968,8 @@ class docParaTypeSub(supermod.docParaType):
         self.programlisting = []
         self.images = []
 
+        self.ordered_children = []
+
     def buildChildren(self, child_, nodeName_):
         supermod.docParaType.buildChildren(self, child_, nodeName_)
 
@@ -1058,6 +1060,11 @@ class docParaTypeSub(supermod.docParaType):
             obj_ = supermod.docTableType.factory()
             obj_.build(child_)
             self.content.append(obj_)
+        else:
+            obj_ = None
+
+        if obj_:
+            self.ordered_children.append(obj_)
 
 
 supermod.docParaType.subclass = docParaTypeSub

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1290,22 +1290,27 @@ class SphinxRenderer:
         neighbouring instances of these things tend to each be in a separate neighbouring para tag.
         """
 
-        nodelist = self.render_iterable(node.content)
-        nodelist.extend(self.render_iterable(node.images))
+        nodelist = []
 
-        if self.app.config.breathe_order_parameters_first:  # type: ignore
-            # Order parameters before simplesects, which mainly are return/warnings/remarks
-            definition_nodes = self.render_iterable(node.parameterlist)
-            definition_nodes.extend(self.render_iterable(node.simplesects))
+        if self.context and self.context.directive_args[0] == "doxygenpage":
+            nodelist.extend(self.render_iterable(node.ordered_children))
         else:
-            # Returns, user par's, etc
-            definition_nodes = self.render_iterable(node.simplesects)
-            # Parameters/Exceptions
-            definition_nodes.extend(self.render_iterable(node.parameterlist))
+            nodelist.extend(self.render_iterable(node.content))
+            nodelist.extend(self.render_iterable(node.images))
 
-        if definition_nodes:
-            definition_list = nodes.definition_list("", *definition_nodes)
-            nodelist.append(definition_list)
+            if self.app.config.breathe_order_parameters_first:  # type: ignore
+                # Order parameters before simplesects, which mainly are return/warnings/remarks
+                definition_nodes = self.render_iterable(node.parameterlist)
+                definition_nodes.extend(self.render_iterable(node.simplesects))
+            else:
+                # Returns, user par's, etc
+                definition_nodes = self.render_iterable(node.simplesects)
+                # Parameters/Exceptions
+                definition_nodes.extend(self.render_iterable(node.parameterlist))
+
+            if definition_nodes:
+                definition_list = nodes.definition_list("", *definition_nodes)
+                nodelist.append(definition_list)
 
         return [nodes.paragraph("", "", *nodelist)]
 


### PR DESCRIPTION
When rendering Doxygen pages one expects content to appear in the
written order. As of today `para` sections content was grouped
separately depending on its type, causing out-of-order content in some
pages.

Fixes #648 