### PR TITLE
Add missing getter and setter for csharp

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1844,9 +1844,19 @@ class SphinxRenderer:
             typename = ''.join(n.astext() for n in self.render(node.get_type()))
             if dom == 'c' and '::' in typename:
                 typename = typename.replace('::', '.')
+            elif dom == 'cs':
+                typename = typename.replace(' ', '')
             elements.append(typename)
             elements.append(name)
             elements.append(node.get_argsstring())
+            if dom == 'cs':
+                if node.get_gettable() or node.get_settable():
+                    elements.append('{')
+                    if node.get_gettable():
+                        elements.append('get;')
+                    if node.get_settable():
+                        elements.append('set;')
+                    elements.append('}')
             elements.append(self.make_initializer(node))
             declaration = ' '.join(elements)
         if not dom or dom in ('c', 'cpp', 'py', 'cs'):


### PR DESCRIPTION
Fix #660 

- Add missing getter and setter for csharp
- Remove spaces in typename to handle the generic type correctly:
  ![image](https://user-images.githubusercontent.com/2201482/112782962-cb8a8a80-9080-11eb-962d-f375a00d911c.png)
  -- to -->
  ![image](https://user-images.githubusercontent.com/2201482/112783012-e65cff00-9080-11eb-9441-aee44b96abd1.png)


