### PR TITLE
Fix: C# should not have inline modifier

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1735,7 +1735,7 @@ class SphinxRenderer:
                 elements = [self.create_template_prefix(node)]
                 if node.static == 'yes':
                     elements.append('static')
-                if node.inline == 'yes':
+                if node.inline == 'yes' and dom != 'cs':
                     elements.append('inline')
                 if node.kind == 'friend':
                     elements.append('friend')


### PR DESCRIPTION
C# shouldn't have inline modifier and sphinx-csharp cannot parse the inline modifier. 