### PR TITLE
Use add_css_file instead of deprecated/removed add_stylesheet

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -593,7 +593,7 @@ def setup(app: Sphinx) -> None:
 
     breathe_css = "breathe.css"
     if (os.path.exists(os.path.join(app.confdir, "_static", breathe_css))):  # type: ignore
-        app.add_stylesheet(breathe_css)
+        app.add_css_file(breathe_css)
 
     def write_file(directory, filename, content):
         # Check the directory exists


### PR DESCRIPTION
As the title says. It was deprecated in Sphinx v1.8, and will be removed in the upcomming v4.