### PR TITLE
Fixes for Sphinx v4

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,18 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         sphinx-version:
           - 3.0.4
           - 3.1.2
           - 3.2.1
           - 3.3.1
           - 3.4.3
-          - 3.5.0
-          - git+https://github.com/sphinx-doc/sphinx.git@3.5.x
-          - git+https://github.com/sphinx-doc/sphinx.git@3.x
-          # master (Sphinx 4) will require at least Python 3.6, so disable it for now
-          #- git+https://github.com/sphinx-doc/sphinx.git@master
+          - 3.5.4
+          - git+https://github.com/sphinx-doc/sphinx.git@4.0.x
+          # enable 4.x again when 4.0.x has been merged into it
+          #- git+https://github.com/sphinx-doc/sphinx.git@4.x
+          - git+https://github.com/sphinx-doc/sphinx.git@master
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=3.0,<3.6
+Sphinx>=3.0,<5
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0,<3.6', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<5', 'docutils>=0.12', 'six>=1.9']
 
-if sys.version_info < (3, 5):
-    print('ERROR: Sphinx requires at least Python 3.5 to run.')
+if sys.version_info < (3, 6):
+    print('ERROR: Sphinx requires at least Python 3.6 to run.')
     sys.exit(1)
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -288,11 +288,21 @@ def test_render_func(app):
                                   param=[WrappedParam(type_=WrappedLinkedText(content_=[WrappedMixedContainer(value=u'int')]))])
     signature = find_node(render(app, member_def), 'desc_signature')
     assert signature.astext().startswith('void')
-    assert find_node(signature, 'desc_name')[0] == 'foo'
+    if sphinx.version_info[0] < 4:
+        assert find_node(signature, 'desc_name')[0] == 'foo'
+    else:
+        n = find_node(signature, 'desc_name')[0]
+        assert isinstance(n, sphinx.addnodes.desc_sig_name)
+        assert len(n) == 1
+        assert n[0] == 'foo'
     params = find_node(signature, 'desc_parameterlist')
     assert len(params) == 1
     param = params[0]
-    assert param[0] == 'int'
+    if sphinx.version_info[0] < 4:
+        assert param[0] == 'int'
+    else:
+        assert isinstance(param[0], sphinx.addnodes.desc_sig_keyword_type)
+        assert param[0][0] == 'int'
 
 
 def test_render_typedef(app):
@@ -312,10 +322,15 @@ def test_render_c_function_typedef(app):
                                   type_='void* (*', name='voidFuncPtr', argsstring=')(float, int)')
     signature = find_node(render(app, member_def, domain='c'), 'desc_signature')
     assert signature.astext().startswith('typedef void *')
-    params = find_node(signature, 'desc_parameterlist')
-    assert len(params) == 2
-    assert params[0].astext() == "float"
-    assert params[1].astext() == "int"
+    if sphinx.version_info[0] < 4:
+        params = find_node(signature, 'desc_parameterlist')
+        assert len(params) == 2
+        assert params[0].astext() == "float"
+        assert params[1].astext() == "int"
+    else:
+        # the use of desc_parameterlist in this case was not correct,
+        # it should only be used for a top-level function
+        pass
 
 
 def test_render_using_alias(app):


### PR DESCRIPTION
Sphinx v4 is being released soon:
- Enlarge accepted Sphinx version range to ``<5``.
- Update CI scripts to test last v3 version, the v4 branches, the v5 branch.
- Only stop testing with Python 3.5 as it is no longer supported in Sphinx.
- Adapt renderer and tests to new declaration styling in the C and C++ domains.