### PR TITLE
Fix paragraph in paragraph rendering

### DIFF
--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -204,7 +204,6 @@ from breathe import path_handler
 from sphinx.application import Sphinx
 
 import os
-import six
 from typing import Any, Callable, Dict, List
 
 
@@ -325,7 +324,7 @@ class NodeTypeAccessor(Accessor):
         except AttributeError as e:
             # Horrible hack to silence errors on filtering unicode objects
             # until we fix the parsing
-            if type(data_object) == six.text_type:
+            if type(data_object) == str:
                 return "unicode"
             else:
                 raise e

--- a/breathe/renderer/mask.py
+++ b/breathe/renderer/mask.py
@@ -18,9 +18,6 @@ matching.
 
 """
 
-import six
-
-
 class NoParameterNamesMask:
     def __init__(self, data_object) -> None:
         self.data_object = data_object
@@ -46,7 +43,7 @@ class MaskFactory(MaskFactoryBase):
         except AttributeError as e:
             # Horrible hack to silence errors on filtering unicode objects
             # until we fix the parsing
-            if isinstance(data_object, six.text_type):
+            if isinstance(data_object, str):
                 node_type = "unicode"
             else:
                 raise e

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -26,7 +26,6 @@ except ImportError:
     cs = None
 
 import re
-import six
 import textwrap
 from typing import Callable, cast, Dict, List, Optional, Tuple, Type, Union  # noqa
 
@@ -366,7 +365,7 @@ def get_param_decl(param):
         if node is not None:
             for p in node.content_:
                 value = p.value
-                if not isinstance(value, six.text_type):
+                if not isinstance(value, str):
                     value = value.valueOf_
                 result.append(value)
         return ' '.join(result)
@@ -555,7 +554,7 @@ class SphinxRenderer:
         node = node_stack[0]
         # An enumvalue node doesn't have location, so use its parent node for detecting
         # the domain instead.
-        if isinstance(node, six.string_types) or node.node_type == "enumvalue":
+        if isinstance(node, str) or node.node_type == "enumvalue":
             node = node_stack[1]
         filename = get_filename(node)
         if not filename and node.node_type == "compound":
@@ -917,7 +916,7 @@ class SphinxRenderer:
                 return [nodes.paragraph('', '', nodes.Text(line))
                         for line in node.split(delimiter) if line.strip()]
             return [nodes.Text(node)]
-        if node == six.u(" "):
+        if node == " ":
             return [nodes.Text(node)]
         return []
 
@@ -2020,7 +2019,7 @@ class SphinxRenderer:
         if node.type_:
             type_nodes = self.render(node.type_)
             # Render keywords as annotations for consistency with the cpp domain.
-            if len(type_nodes) > 0 and isinstance(type_nodes[0], six.text_type):
+            if len(type_nodes) > 0 and isinstance(type_nodes[0], str):
                 first_node = type_nodes[0]
                 for keyword in ['typename', 'class']:
                     if first_node.startswith(keyword + ' '):
@@ -2184,7 +2183,7 @@ class SphinxRenderer:
             self.context = cast(RenderContext, self.context)
             if not self.filter_.allow(self.context.node_stack):
                 pass
-            elif isinstance(node, six.string_types):
+            elif isinstance(node, str):
                 result = self.visit_unicode(node)
             else:
                 method = SphinxRenderer.methods.get(node.node_type, SphinxRenderer.visit_unknown)

--- a/examples/tinyxml/tinyxml.h
+++ b/examples/tinyxml/tinyxml.h
@@ -1730,7 +1730,7 @@ public:
 	void SetIndent( const char* _indent )			{ indent = _indent ? _indent : "" ; }
 	/// Query the indention string.
 	const char* Indent()							{ return indent.c_str(); }
-	/** Set the line breaking string. By default set to newline (\n). 
+	/** Set the line breaking string. By default set to newline (\c \n).
 		Some operating systems prefer other characters, or can be
 		set to the null/empty string for no indentation.
 	*/

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,4 +3,3 @@ Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
 Sphinx>=3.0,<3.6
-six>=1.9.0


### PR DESCRIPTION
- Remove use of the ``six`` module as Python 3 is required anyway.
- Fix #666. The same problem is present in the Breathe docs at https://breathe.readthedocs.io/en/latest/doxygen.html#_CPPv4NUt16_ex_doxygen_group2N1E where there is a wrong paragraph break after "Also see".
- Fix markup in the Tinyxml example where a verbatim ``\n`` was interpreted as a line break due to missing [``\c``](https://www.doxygen.nl/manual/commands.html#cmdc).