### PR TITLE
doxygenfunction, strip names before lookup

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -62,6 +62,8 @@ class DoxygenFunctionDirective(BaseDirective):
             (namespace, function_name) = namespaced_function.rsplit("::", 1)
         except ValueError:
             (namespace, function_name) = "", namespaced_function
+        namespace = namespace.strip()
+        function_name = function_name.strip()
 
         try:
             project_info = self.project_info_factory.create_project_info(self.options)


### PR DESCRIPTION
While investigating #656 I found that with
```rst
.. doxygenfunction:: CreateIObject (ObjectDataInterface *object_data)
```
the name it looks for is ``CreateIObject `` (note trailing whitespace) which fails, so strip the name.