### PR TITLE
Remove stale six dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 '''
 
-requires = ['Sphinx>=3.0,<5', 'docutils>=0.12', 'six>=1.9']
+requires = ['Sphinx>=3.0,<5', 'docutils>=0.12']
 
 if sys.version_info < (3, 6):
     print('ERROR: Sphinx requires at least Python 3.6 to run.')


### PR DESCRIPTION
The use of six was removed entirely but a dependency on it was left
in setup.py.  Remove it.