### PR TITLE
Start pytest via module instead of exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ clean:
 
 .PHONY: test
 test:
-	cd tests && pytest -v
+	cd tests && python3 -m pytest -v
 
 .PHONY: dev-test
 dev-test:
-	cd tests && PYTHONPATH=../:$(PYTHONPATH) pytest -v
+	cd tests && PYTHONPATH=../:$(PYTHONPATH) python3 -m pytest -v
 
 .PHONY: flake8
 flake8:

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export PYTHONPATH=../
+export PYTHONPATH="../${PYTHONPATH:+:$PYTHONPATH}"
 
-pytest -v
+python3 -m pytest -v


### PR DESCRIPTION
For some reason the ``pytest`` executable is apparently not always installed, but starting it via the module import should(TM) work.