### PR TITLE
Fix retval rendering

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -2137,10 +2137,12 @@ class SphinxRenderer:
                                 nodes.strong(dir, dir),
                                 nodes.Text(' ', ' ')
                             ]
-
-            name = nodes.field_name(
-                '', nodes.Text(fieldListName[node.kind] + ' '),
-                *nameNodes)
+            # it seems that Sphinx expects the name to be a single node,
+            # so let's make it that
+            txt = fieldListName[node.kind] + ' '
+            for n in nameNodes:
+                txt += n.astext()
+            name = nodes.field_name('', nodes.Text(txt))
             bodyNodes = self.render_optional(item.parameterdescription)
             # TODO: is it correct that bodyNodes is either empty or a single paragraph?
             assert len(bodyNodes) <= 1, bodyNodes


### PR DESCRIPTION
Doxygen has both ``\returns desc`` and ``\retval arg desc`` which is converted to the equivalent of ``:returns: desc`` and ``:returns arg: desc``. As noted in https://github.com/michaeljones/breathe/issues/683#issuecomment-830030073, all the build-in Sphinx domains assumes the ``returns`` field to have no argument, both it still handles them. Except, it must apparently be a single docutils node. This PR makes it that.

Example for reproduction:
``test.hpp``
```c++
/*! Something myFunction short.
 *
 * Something myFunction long.
 *
 * @retval "Discovery status" - The discovery status
 * @retval MAX_EVENTS         - The pointer
 * @return ReturnDesc
 */
void myFunction();
```
``index.rst``:
```rst
.. doxygenfunction:: myFunction

.. cpp:function:: void f()

	:returns: something
	:returns arg: somethingElse
```

Fixes #684.