### PR TITLE
support externally hosted images

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -27,6 +27,7 @@ try:
 except ImportError:
     cs = None
 
+import os
 import re
 import textwrap
 from typing import Callable, cast, Dict, List, Optional, Tuple, Type, Union  # noqa
@@ -1443,6 +1444,9 @@ class SphinxRenderer:
         """Output docutils image node using name attribute from xml as the uri"""
 
         path_to_image = self.project_info.sphinx_abs_path_to_file(node.name)
+        if not os.path.exists(path_to_image):
+            path_to_image = node.name
+
         options = {"uri": path_to_image}
         return [nodes.image("", **options)]
 


### PR DESCRIPTION
Observed an issue when attempting to process tinyxml documentation. After generating XML documentation from tinyxml, processing it through breathe would result in the following warning:

```
sphinx.errors.SphinxWarning: ...\tinyxml.rst::image file not readable: xml/tinyxml/https:/github.com/leethomason/tinyxml2/actions/workflows/test.yml/badge.svg
```

The project prefix `xml/tinyxml/` had been injected into the URI of the image. This commit tries to help mitigate using an absolute path building for external images by checking if the prepared absolute path actually exists. If not, assume the image is an externally hosted image by passing the docutils uri directly to the node's `uri` attribute.