### PR TITLE
support externally hosted images (v2)

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -11,6 +11,7 @@ from sphinx.application import Sphinx
 from sphinx.directives import ObjectDescription
 from sphinx.domains import cpp, c, python
 from sphinx.util.nodes import nested_parse_with_titles
+from sphinx.util import url_re
 from sphinx.ext.graphviz import (
     graphviz,
     html_visit_graphviz,
@@ -1509,7 +1510,10 @@ class SphinxRenderer:
     def visit_docimage(self, node) -> List[Node]:
         """Output docutils image node using name attribute from xml as the uri"""
 
-        path_to_image = self.project_info.sphinx_abs_path_to_file(node.name)
+        path_to_image = node.name
+        if not url_re.match(path_to_image):
+            path_to_image = self.project_info.sphinx_abs_path_to_file(path_to_image)
+
         options = {"uri": path_to_image}
         return [nodes.image("", **options)]
 


### PR DESCRIPTION
Observed an issue when attempting to process tinyxml documentation. After generating XML documentation from tinyxml, processing it through breathe would result in the following warning:

```
sphinx.errors.SphinxWarning: ...\tinyxml.rst::image file not readable: xml/tinyxml/https:/github.com/leethomason/tinyxml2/actions/workflows/test.yml/badge.svg
```

The project prefix `xml/tinyxml/` had been injected into the URI of the image. This commit tries to help mitigate using an absolute path building for external images by checking if the URI defines a URL schema (using implementation from Sphinx's utility class).  If a URL schema is detected, assume the source is an external image and just passthrough the value to the generate image node's uri value. Otherwise, default to building a Sphinx project's absolute path to the image.

- Crudely tested with tinyxml (includes external images) and oglft's documentation (with internal images).
- Sphinx's `url_re` call should be available in oldest supported Sphinx revision listed ([v2.3.1](https://github.com/sphinx-doc/sphinx/blob/v2.3.1/sphinx/util/__init__.py)).