### PR TITLE
Handle parsing errors

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -2097,7 +2097,7 @@ class SphinxRenderer:
                         location=self.state.state_machine.get_source_and_line(),
                         config=self.app.config)
                     try:
-                        # we really should use _parse_template_paramter()
+                        # we really should use _parse_template_parameter()
                         # but setting a name there is non-trivial, so we use type
                         ast = parser._parse_type(named='single', outer='templateParam')
                         assert ast.name is None

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -2067,8 +2067,8 @@ class SphinxRenderer:
         signode += nodes.Text(node.name)
         return [desc]
 
-    def visit_param(self, node: compound.paramTypeSub, *,
-                    insertDeclNameByParsing: bool = False) -> List[Node]:
+    def visit_templateparam(self, node: compound.paramTypeSub, *,
+                            insertDeclNameByParsing: bool = False) -> List[Node]:
         nodelist = []
 
         # Parameter type
@@ -2096,15 +2096,22 @@ class SphinxRenderer:
                         ''.join(n.astext() for n in nodelist),
                         location=self.state.state_machine.get_source_and_line(),
                         config=self.app.config)
-                    ast = parser._parse_type(named='single', outer='templateParam')
-                    assert ast.name is None
-                    nn = cpp.ASTNestedName(
-                        names=[cpp.ASTNestedNameElement(cpp.ASTIdentifier(node.declname), None)],
-                        templates=[False], rooted=False)
-                    ast.name = nn
-                    # the actual nodes don't matter, as it is astext()-ed later
-                    nodelist = [nodes.Text(str(ast))]
-                    appendDeclName = False
+                    try:
+                        # we really should use _parse_template_paramter()
+                        # but setting a name there is non-trivial, so we use type
+                        ast = parser._parse_type(named='single', outer='templateParam')
+                        assert ast.name is None
+                        nn = cpp.ASTNestedName(
+                            names=[cpp.ASTNestedNameElement(
+                                cpp.ASTIdentifier(node.declname), None)],
+                            templates=[False], rooted=False)
+                        ast.name = nn
+                        # the actual nodes don't matter, as it is astext()-ed later
+                        nodelist = [nodes.Text(str(ast))]
+                        appendDeclName = False
+                    except cpp.DefinitionError:
+                        # happens with "typename ...Args", so for now, just append
+                        pass
 
             if appendDeclName:
                 if nodelist:
@@ -2134,7 +2141,7 @@ class SphinxRenderer:
         for i, item in enumerate(node.param):
             if i:
                 nodelist.append(nodes.Text(", "))
-            nodelist.extend(self.visit_param(item, insertDeclNameByParsing=True))
+            nodelist.extend(self.visit_templateparam(item, insertDeclNameByParsing=True))
         self.output_defname = True
         return nodelist
 
@@ -2273,7 +2280,6 @@ class SphinxRenderer:
         "compoundref": visit_compoundref,
         "mixedcontainer": visit_mixedcontainer,
         "description": visit_description,
-        "param": visit_param,
         "templateparamlist": visit_templateparamlist,
         "docparamlist": visit_docparamlist,
         "docxrefsect": visit_docxrefsect,


### PR DESCRIPTION
(This depends on / includes #698)

In a few places the C++ domain in Sphinx is used to parse fragments, but potential errors are not handled. This tries to fix that.
One case is the parsing of the function parameters in ``doxygenfunction``, so ``.. doxygenfunction:: f(`` would crash Breathe.
The second case is parsing the function parameters in the XML, I don't know how to trigger that directly, but it should be handled now.
The third case is in the hax to insert the name in template parameters (#681). For parameters ``typename ...Args`` it will trigger a parsing error (observed in the pybind11 project).

Note, the third case is only enabled when using Sphinx 4.1 which is still not released, but probably will soon'ish.