### PR TITLE
Adds argument to doxygengroup to display just the description.

### DIFF
--- a/breathe/directives/content_block.py
+++ b/breathe/directives/content_block.py
@@ -27,6 +27,7 @@ class _DoxygenContentBlockDirective(BaseDirective):
         "private-members": flag,
         "undoc-members": flag,
         "no-link": flag,
+        "desc-only": flag,
     }
     has_content = False
 

--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -596,6 +596,9 @@ class FilterFactory:
         if "members" in filter_options:
             filter_options["members"] = ""
 
+        if "desc-only" in filter_options:
+            return self._create_description_filter(True, "compounddef", options)
+
         node = Node()
         grandparent = Ancestor(2)
         has_grandparent = HasAncestorFilter(2)

--- a/documentation/source/directives.rst
+++ b/documentation/source/directives.rst
@@ -228,8 +228,8 @@ group. A doxygen group can be declared with specific doxygen markup in the
 source comments as covered in the `doxygen grouping documentation`_.
 
 It takes the standard ``project``, ``path``, ``outline`` and ``no-link`` options
-and additionally the ``content-only``, ``members``, ``protected-members``,
-``private-members`` and ``undoc-members`` options.
+and additionally the ``content-only``, ``desc-only``, ``members``,
+``protected-members``, ``private-members`` and ``undoc-members`` options.
 
 ::
 
@@ -237,6 +237,7 @@ and additionally the ``content-only``, ``members``, ``protected-members``,
       :project: ...
       :path: ...
       :content-only:
+      :desc-only:
       :outline:
       :members:
       :protected-members:
@@ -307,8 +308,8 @@ doxygennamespace
 This directive generates the appropriate output for the contents of a namespace.
 
 It takes the standard ``project``, ``path``, ``outline`` and ``no-link`` options
-and additionally the ``content-only``, ``members``, ``protected-members``,
-``private-members`` and ``undoc-members`` options.
+and additionally the ``content-only``, ``desc-only``, ``members``,
+``protected-members``, ``private-members`` and ``undoc-members`` options.
 
 To reference a nested namespace, the full namespaced path must be provided, e.g.
 ``foo::bar`` for the ``bar`` namespace inside the ``foo`` namespace.
@@ -319,6 +320,7 @@ To reference a nested namespace, the full namespaced path must be provided, e.g.
       :project: ...
       :path: ...
       :content-only:
+      :desc-only:
       :outline:
       :members:
       :protected-members:

--- a/documentation/source/group.rst
+++ b/documentation/source/group.rst
@@ -9,14 +9,19 @@ group. A doxygen group can be declared with specific doxygen markup in the
 source comments as cover in the `doxygen grouping documentation`_.
 
 It takes the standard ``project``, ``path``, ``outline`` and ``no-link`` options
-and additionally the ``content-only``, ``members``, ``protected-members``,
-``private-members``, ``undoc-members`` and ``inner`` options.
+and additionally the ``content-only``, ``desc-only``, ``members``,
+``protected-members``, ``private-members``, ``undoc-members`` and ``inner``
+options.
 
 ``content-only``
    If this flag is specified, then the directive does not output the name of the
    group or the group description and instead outputs the contents of the group.
    This can be useful if the groups are only used for organizational purposes
    and not to provide additional information.
+
+``desc-only``
+   If specified, only the description and name of the group will be
+   displayed.
 
 ``members``
    If specified, the public members of any classes in the group output will be

--- a/documentation/source/namespace.rst
+++ b/documentation/source/namespace.rst
@@ -8,14 +8,18 @@ This directive generates the appropriate output for the contents of a
 namespace.
 
 It takes the standard ``project``, ``path``, ``outline`` and ``no-link`` options
-and additionally the ``content-only``, ``members``, ``protected-members``,
-``private-members`` and ``undoc-members`` options.
+and additionally the ``content-only``, ``desc-only``, ``members``,
+``protected-members``, ``private-members`` and ``undoc-members`` options.
 
 ``content-only``
    If this flag is specified, then the directive does not output the name of the
    namespace or the namespace description and instead outputs the contents of
    the namespace. This can be useful for structuring your documentation but
    leaving out the namespace declaration itself which is often undocumented.
+
+``desc-only``
+   If specified, only the description and name of the namespace will be
+   displayed.
 
 ``members``
    If specified, the public members of any classes in the namespace output will be


### PR DESCRIPTION
Any doxygen directive that uses the _DoxygenContentBlockDirective can now display just the description, like so:

```
.. doxygengroup:: GROUPNAME
   :description-only:
```

I frequently build up groups from their components, so its useful to be able to display just the description. 

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>