### PR TITLE
Make doxygenfunction more robust when matching parameters

### DIFF
--- a/breathe/directives/function.py
+++ b/breathe/directives/function.py
@@ -158,7 +158,11 @@ class DoxygenFunctionDirective(BaseDirective):
                 continue
             declarator = p.arg.type.decl
             while hasattr(declarator, 'next'):
-                declarator = declarator.next  # type: ignore
+                if isinstance(declarator, cpp.ASTDeclaratorParen):
+                    assert hasattr(declarator, 'inner')
+                    declarator = declarator.inner  # type: ignore
+                else:
+                    declarator = declarator.next  # type: ignore
             assert hasattr(declarator, 'declId')
             declarator.declId = None  # type: ignore
             p.arg.init = None  # type: ignore

--- a/breathe/directives/function.py
+++ b/breathe/directives/function.py
@@ -154,10 +154,17 @@ class DoxygenFunctionDirective(BaseDirective):
         # strip everything that doesn't contribute to overloading
 
         def stripParamQual(paramQual):
+            paramQual.exceptionSpec = None  # type: ignore
+            paramQual.final = None  # type: ignore
+            paramQual.override = None  # type: ignore
+            # TODO: strip attrs when Doxygen handles them
+            paramQual.initializer = None  # type: ignore
+            paramQual.trailingReturn = None  # type: ignore
             for p in paramQual.args:
                 if p.arg is None:
                     assert p.ellipsis
                     continue
+                p.arg.init = None  # type: ignore
                 declarator = p.arg.type.decl
                 while hasattr(declarator, 'next'):
                     if isinstance(declarator, cpp.ASTDeclaratorParen):
@@ -166,8 +173,8 @@ class DoxygenFunctionDirective(BaseDirective):
                     else:
                         declarator = declarator.next  # type: ignore
                 assert hasattr(declarator, 'declId')
+                assert isinstance(declarator, cpp.ASTDeclaratorNameParamQual)
                 declarator.declId = None  # type: ignore
-                p.arg.init = None  # type: ignore
         stripParamQual(paramQual)
         return paramQual
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -220,6 +220,7 @@ breathe_projects = {
     "cpp_enum":"../../examples/specific/cpp_enum/xml/",
     "cpp_union":"../../examples/specific/cpp_union/xml/",
     "cpp_function":"../../examples/specific/cpp_function/xml/",
+    "cpp_function_lookup":"../../examples/specific/cpp_function_lookup/xml/",
     "cpp_friendclass":"../../examples/specific/cpp_friendclass/xml/",
     "cpp_inherited_members":"../../examples/specific/cpp_inherited_members/xml/",
     "cpp_trailing_return_type":"../../examples/specific/cpp_trailing_return_type/xml/",

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -247,6 +247,29 @@ Test for issue 717.
 .. doxygenfile:: cpp_constexpr_hax.h
    :project: cpp_constexpr_hax
 
+C++ Function Lookup
+-------------------
+
+.. cpp:namespace:: @ex_specific_cpp_function_lookup
+
+.. doxygenfunction:: fInit(int)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fPlain(int)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fPtr(int*)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fLRef(int&)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fRRef(int&&)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fParamPack(T...)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fMemPtr(int A::*)
+   :project: cpp_function_lookup
+.. doxygenfunction:: fParen(void (*)())
+   :project: cpp_function_lookup
+
+
 Doxygen xrefsect
 ----------------
 

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -252,6 +252,22 @@ C++ Function Lookup
 
 .. cpp:namespace:: @ex_specific_cpp_function_lookup
 
+.. doxygenfunction:: fNoexcept()
+   :project: cpp_function_lookup
+.. doxygenfunction:: fFinal()
+   :project: cpp_function_lookup
+.. doxygenfunction:: fOverride()
+   :project: cpp_function_lookup
+
+This one should actually have ``[[myattr]]`` but Doxygen seems to not put attributes into the XML:
+
+.. doxygenfunction:: fAttr()
+   :project: cpp_function_lookup
+.. doxygenfunction:: fFInit()
+   :project: cpp_function_lookup
+.. doxygenfunction:: fTrailing()
+   :project: cpp_function_lookup
+
 .. doxygenfunction:: fInit(int)
    :project: cpp_function_lookup
 .. doxygenfunction:: fPlain(int)

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -285,6 +285,9 @@ This one should actually have ``[[myattr]]`` but Doxygen seems to not put attrib
 .. doxygenfunction:: fParen(void (*)())
    :project: cpp_function_lookup
 
+.. doxygenfunction:: fParenPlain(void (*)(int))
+   :project: cpp_function_lookup
+
 
 Doxygen xrefsect
 ----------------

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -26,6 +26,7 @@ projects  = nutshell alias rst inline namespacefile array inheritance \
 			enum define interface xrefsect tables \
 			cpp_anon cpp_enum cpp_union cpp_function cpp_friendclass \
 			cpp_inherited_members cpp_trailing_return_type cpp_constexpr_hax \
+			cpp_function_lookup \
 			c_file c_struct c_enum c_typedef c_macro c_union membergroups
 
 special   = programlisting decl_impl multifilexml auto class typedef

--- a/examples/specific/cpp_function_lookup.cfg
+++ b/examples/specific/cpp_function_lookup.cfg
@@ -1,0 +1,11 @@
+PROJECT_NAME     = "C++ Function Lookup"
+OUTPUT_DIRECTORY = cpp_function_lookup
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = cpp_function_lookup.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES

--- a/examples/specific/cpp_function_lookup.h
+++ b/examples/specific/cpp_function_lookup.h
@@ -1,0 +1,10 @@
+void fInit(int arg = 42);
+void fPlain(int arg);
+void fPtr(int *arg);
+void fLRef(int &arg);
+void fRRef(int &&arg);
+//template<typename ...T> // TODO: add this again when the parsing has been fixed
+void fParamPack(T ...arg);
+class A {};
+void fMemPtr(int A::*arg);
+void fParen(void (*arg)());

--- a/examples/specific/cpp_function_lookup.h
+++ b/examples/specific/cpp_function_lookup.h
@@ -1,3 +1,12 @@
+// stuff on the paramQual
+void fNoexcept() noexcept;
+void fFinal() final;
+void fOverride() override;
+void fAttr() [[myattr]]; // TODO: Doxygen seems to strip attributes
+void fFInit() = default;
+auto fTrailing() -> int;
+
+// different parameters
 void fInit(int arg = 42);
 void fPlain(int arg);
 void fPtr(int *arg);

--- a/examples/specific/cpp_function_lookup.h
+++ b/examples/specific/cpp_function_lookup.h
@@ -17,3 +17,6 @@ void fParamPack(T ...arg);
 class A {};
 void fMemPtr(int A::*arg);
 void fParen(void (*arg)());
+
+// different parameters in a function pointer
+void fParenPlain(void (*arg)(int argInner));

--- a/examples/specific/cpp_function_lookup.h
+++ b/examples/specific/cpp_function_lookup.h
@@ -12,7 +12,7 @@ void fPlain(int arg);
 void fPtr(int *arg);
 void fLRef(int &arg);
 void fRRef(int &&arg);
-//template<typename ...T> // TODO: add this again when the parsing has been fixed
+template<typename ...T>
 void fParamPack(T ...arg);
 class A {};
 void fMemPtr(int A::*arg);


### PR DESCRIPTION
(This depends on / includes #698)

Fixes the basics of #722, and all(?) other cases where information does not contribute to overload resolution. See ``examples/specific/cpp_function_lookup.h`` for examples (https://github.com/michaeljones/breathe/pull/723/files?file-filters%5B%5D=.h&file-filters%5B%5D=.py#diff-b4e4a1134077e09d357e73a9c4ca3cb49fec09a3264c88bc5119aeaa48990721).

Things that may still fail:
- Two functions only differ in their return type (e.g., a trailing return type with ``decltype(expr)`` which would make all but one overload valid. Currently the trailing return type is stripped. The syntax of ``doxygenfunction`` needs to be expanded to properly handle this.
- Two functions only differ in their template parameter list or (trailing) requires clause. The syntax of ``doxygenfunction`` needs to be expanded to properly handle this.
- An "array" parameter which is equivalent to a pointer parameter (``int *p`` vs. ``int p[]``). The user must use the same syntax as in the code. I'm not sure if it's worth making this work.