### PR TITLE
Print usage message from 'compare'

### DIFF
--- a/documentation/compare
+++ b/documentation/compare
@@ -3,16 +3,22 @@
 first=$1
 second=$2
 
-if [ -z "$second" ]; then
-	echo "Usage: compare <branch name A> <branch name B>"
+if [ -z "$first" ]; then
+	echo "Usage: compare <branch name A> [<branch name B>]"
+	echo ""
+	echo "The second argument defaults to the current branch if not specified"
 	exit 1
+fi
+
+# Remember the branch we're on
+currentbranch=`git symbolic-ref --short HEAD`
+
+if [ -z "$second" ]; then
+	second=$currentbranch
 fi
 
 firstdir=comparison/first
 seconddir=comparison/second
-
-# Remember the branch we're on
-currentbranch=`git symbolic-ref --short HEAD`
 
 # Make sure the output directory exists
 mkdir -p comparison

--- a/documentation/compare
+++ b/documentation/compare
@@ -1,7 +1,12 @@
-#!/bin/sh
+#!/bin/sh -e
 
 first=$1
 second=$2
+
+if [ -z "$second" ]; then
+	echo "Usage: compare <branch name A> <branch name B>"
+	exit 1
+fi
 
 firstdir=comparison/first
 seconddir=comparison/second
@@ -19,8 +24,8 @@ rm -fr $seconddir
 export BREATHE_COMPARE=True
 
 # Checkout the first target
-echo git checkout $1
-git checkout $1
+echo git checkout $first
+git checkout $first
 # Run doxygen for this state
 (cd ../examples/specific; make)
 (cd ../examples/tinyxml; make)
@@ -36,8 +41,8 @@ git checkout Makefile
 
 
 # Checkout the second target and repeat
-echo git checkout $2
-git checkout $2
+echo git checkout $second
+git checkout $second
 (cd ../examples/specific; make)
 (cd ../examples/tinyxml; make)
 (cd ../examples/doxygen; make)


### PR DESCRIPTION
And default the second argument to the current branch if not specified.

As noted in the commit message, this is due to my own confusion when attempting to use the script after a long time :) 