### PR TITLE
Fix sys.path adjustment in doc config

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: build the documentation
         run: |
-          PYTHONPATH="${PWD}${PYTHONPATH:+:$PYTHONPATH}" make html
+          make html
           rm documentation/build/html/.buildinfo
 
       - uses: actions/upload-artifact@v1

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -78,8 +78,9 @@ elif read_the_docs_build:
 
 else:
 
-    # For our usual dev build we'll be in the 'documentation' directory
-    sys.path.append('../')
+    # For our usual dev build we'll be in the 'documentation' directory but Sphinx seems to set the
+    # current working directory to 'source' so we append relative to that
+    sys.path.append('../../')
 
     # Check if it matches a pure tag number vX.Y.Z, rather than vX.Y.Z-91-g8676988 which is how
     # non-tagged commits are described (ie. relative to the last tag)


### PR DESCRIPTION
It seems that CI already changes the PYTHONPATH to adjust for this but
this allows us to run 'make html' in either the root or 'documentation'
and have it work as it used to.