### PR TITLE
Fix sphinxrenderer.py class visitor for C#

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -960,6 +960,8 @@ class SphinxRenderer:
         parent_context = self.context.create_child_context(file_data)
         new_context = parent_context.create_child_context(nodeDef)
 
+        domain = self.get_domain()
+
         with WithContext(self, new_context):
             # Pretend that the signature is being rendered in context of the
             # definition, for proper domain detection
@@ -986,7 +988,7 @@ class SphinxRenderer:
                     decls.append(',')
                 else:
                     first = False
-                if base.prot is not None:
+                if base.prot is not None and domain != 'cs':
                     decls.append(base.prot)
                 if base.virt == 'virtual':
                     decls.append('virtual')


### PR DESCRIPTION
Inhertitance in C# does not have a protection level and is always `public`, but this should not be shown. This code fixes this but there is still an issue. 

Example of current [incorrect output](https://vr-modeling.readthedocs.io/Assets/Scripts/index.html#libigl-overview) (`public` should not be rendered):
![image](https://user-images.githubusercontent.com/42413282/131998940-9dc1d86f-6395-4809-99f8-542a05b55346.png)

### Remaining Issue
The `domain` is sometimes returned as `None` or `''`. For example, when using the directive below. Then the classes are not linked to the correct `cs` domain, so we get the incorrect behaviour again.
```
.. doxygennamespace:: Libigl :no-link:
```

Is the issue in `get_domain` or because the location in the `node` is not set correctly?
https://github.com/michaeljones/breathe/blob/3023db02431ca70dd39fbbbc8a4dcd671a5b529e/breathe/renderer/sphinxrenderer.py#L544-L565