### PR TITLE
cicd: track sphinx 4.2.x development series

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
           - 3.5.4
           - 4.0.3
           - 4.1.2
-          - git+https://github.com/sphinx-doc/sphinx.git@4.1.x
+          - git+https://github.com/sphinx-doc/sphinx.git@4.2.x
           - git+https://github.com/sphinx-doc/sphinx.git@4.x
           - git+https://github.com/sphinx-doc/sphinx.git@master
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
   - Make doxygenfunction more robust when matching parameters. `#722 <https://github.com/michaeljones/breathe/issues/722>`__ `#723 <https://github.com/michaeljones/breathe/pull/723>`__
   - Separate, link and style the changelog. `#735 <https://github.com/michaeljones/breathe/pull/735>`__
   - Update changelog and readme ahead of release. `#739 <https://github.com/michaeljones/breathe/pull/739>`__
+  - CICD: Track Sphinx 4.2.x development series. `#741 <https://github.com/michaeljones/breathe/pull/741>`__
 
 - 2021-05-06 - **Breathe v4.30.0**
 


### PR DESCRIPTION
Development on 4.1.x is over so the upstream branch no longer exists.