### PR TITLE
Allow access to __version__ with imports

### DIFF
--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -1,13 +1,16 @@
-from breathe.directives.setup import setup as directive_setup
-from breathe.file_state_cache import setup as file_state_cache_setup
-from breathe.renderer.sphinxrenderer import setup as renderer_setup
-
-from sphinx.application import Sphinx
-
 __version__ = "4.31.0"
 
 
-def setup(app: Sphinx):
+def setup(app):
+
+    from breathe.directives.setup import setup as directive_setup
+    from breathe.file_state_cache import setup as file_state_cache_setup
+    from breathe.renderer.sphinxrenderer import setup as renderer_setup
+
+    from sphinx.application import Sphinx
+
+    app: Sphinx = app
+
     directive_setup(app)
     file_state_cache_setup(app)
     renderer_setup(app)


### PR DESCRIPTION
*This is somewhat out of desperation. Not sure why this is failing on ReadTheDocs*

We move the top level imports into the 'setup' function in order to
allow setup.py to access the __version__ variable in the module without
having to have sphinx available.

I'm not sure if this is for the best but the ReadTheDocs build is
failing and it seems potentially related to this though I've no idea why
it is suddenly happening as we've not changed anything around this to my
understanding.

The ReadTheDocs error is:
```
/envs/latest/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .
Processing /home/docs/checkouts/readthedocs.org/user_builds/breathe/checkouts/latest
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/bin/python /home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpo1quees5
       cwd: /tmp/pip-req-build-wrcudthy
  Complete output (26 lines):
  Traceback (most recent call last):
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 349, in <module>
      main()
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 331, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 117, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/pip-build-env-eaq7p8sq/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 155, in get_requires_for_build_wheel
      config_settings, requirements=['wheel'])
    File "/tmp/pip-build-env-eaq7p8sq/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 135, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-eaq7p8sq/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 259, in run_setup
      self).run_setup(setup_script=setup_script)
    File "/tmp/pip-build-env-eaq7p8sq/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 150, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 11, in <module>
      from breathe import __version__
    File "/tmp/pip-req-build-wrcudthy/breathe/__init__.py", line 1, in <module>
      from breathe.directives.setup import setup as directive_setup
    File "/tmp/pip-req-build-wrcudthy/breathe/directives/__init__.py", line 1, in <module>
      from breathe.finder.factory import FinderFactory
    File "/tmp/pip-req-build-wrcudthy/breathe/finder/__init__.py", line 1, in <module>
      from breathe.project import ProjectInfo
    File "/tmp/pip-req-build-wrcudthy/breathe/project.py", line 3, in <module>
      from sphinx.application import Sphinx
  ModuleNotFoundError: No module named 'sphinx'
  ----------------------------------------
WARNING: Discarding file:///home/docs/checkouts/readthedocs.org/user_builds/breathe/checkouts/latest. Command errored out with exit status 1: /home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/bin/python /home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpo1quees5 Check the logs for full command output.
ERROR: Command errored out with exit status 1: /home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/bin/python /home/docs/checkouts/readthedocs.org/user_builds/breathe/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpo1quees5 Check the logs for full command output. 
```
Which I can reproduce locally on my set up with a standard virtual env.
