### PR TITLE
Allow no-link option in doxygenpage

### DIFF
--- a/breathe/directives/content_block.py
+++ b/breathe/directives/content_block.py
@@ -115,4 +115,5 @@ class DoxygenPageDirective(_DoxygenContentBlockDirective):
         "path": unchanged_required,
         "project": unchanged_required,
         "content-only": flag,
+        "no-link": flag,
     }


### PR DESCRIPTION
Precisely what the title says. Whenever using `.. doxygenpage::` to pull a Doxygen page into its own `rst` document, the implicit link to the page may be redundant with that of the title of the document -- necessary for `.. toctree::` inclusion. That redundancy may cause duplicate ID warnings. 

This patch allows the user to disable such links.