### PR TITLE
renderer: use retval type for the retval fields

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -896,7 +896,7 @@ class SphinxRenderer:
             fieldLists = [fieldList]
 
         # collapse retvals into a single return field
-        if len(fieldLists) != 0:
+        if len(fieldLists) != 0 and sphinx.version_info[0:2] < (4, 3):
             others: nodes.field = []
             retvals: nodes.field = []
             for f in fieldLists[0]:
@@ -2211,7 +2211,8 @@ class SphinxRenderer:
             "param": "param",
             "exception": "throws",
             "templateparam": "tparam",
-            "retval": "returns",
+            # retval support available on Sphinx >= 4.3
+            "retval": "returns" if sphinx.version_info[0:2] < (4, 3) else "retval",
         }
 
         # https://docutils.sourceforge.io/docs/ref/doctree.html#field-list


### PR DESCRIPTION
This change makes `@retval` fields to render as a separate list, independent of the `@return/s` entries.

Depends on https://github.com/sphinx-doc/sphinx/pull/9691

Example:

```c
/**
 * @brief Foo.
 *
 * @param[in] bar Bar
 *
 * @retval 0 If succeeded
 * @retval 1 If something went wrong
 */
int foo(int bar);
```

![image](https://user-images.githubusercontent.com/25011557/135589633-e2961066-10b6-47bf-b3f0-c57505b898c4.png)
