### PR TITLE
Handle specialized template functions

### DIFF
--- a/breathe/directives/function.py
+++ b/breathe/directives/function.py
@@ -45,7 +45,7 @@ class DoxygenFunctionDirective(BaseDirective):
         # Separate possible arguments (delimited by a "(") from the namespace::name
         match = re.match(r"(?:([^:(<]+(?:::[^:(<]+)*)::)?([^(]+)(.*)", self.arguments[0])
         assert match is not None  # TODO: this is probably not appropriate, for now it fixes typing
-        namespace = match.group(1).strip()
+        namespace = (match.group(1) or "").strip()
         function_name = match.group(2).strip()
         args = match.group(3)
 

--- a/breathe/directives/function.py
+++ b/breathe/directives/function.py
@@ -43,17 +43,11 @@ class DoxygenFunctionDirective(BaseDirective):
 
     def run(self) -> List[Node]:
         # Separate possible arguments (delimited by a "(") from the namespace::name
-        match = re.match(r"([^(]*)(.*)", self.arguments[0])
+        match = re.match(r"(?:([^:(<]+(?:::[^:(<]+)*)::)?([^(]+)(.*)", self.arguments[0])
         assert match is not None  # TODO: this is probably not appropriate, for now it fixes typing
-        namespaced_function, args = match.group(1), match.group(2)
-
-        # Split the namespace and the function name
-        try:
-            (namespace, function_name) = namespaced_function.rsplit("::", 1)
-        except ValueError:
-            (namespace, function_name) = "", namespaced_function
-        namespace = namespace.strip()
-        function_name = function_name.strip()
+        namespace = match.group(1).strip()
+        function_name = match.group(2).strip()
+        args = match.group(3)
 
         try:
             project_info = self.project_info_factory.create_project_info(self.options)

--- a/documentation/source/template.rst
+++ b/documentation/source/template.rst
@@ -43,6 +43,17 @@ A function with single template parameter renders as:
 
 ----
 
+.. cpp:namespace:: @ex_specialized_template_function_single
+
+If specialized for a given type it renders as:
+
+----
+
+.. doxygenfunction:: function1< std::string >
+   :project: template_function
+
+----
+
 .. cpp:namespace:: @ex_template_function_multiple
 
 With multiple template parameters it renders as:

--- a/examples/specific/template_function.h
+++ b/examples/specific/template_function.h
@@ -1,3 +1,5 @@
+#include <string>
+
 /**
  * @brief a function with one template arguments
  * 
@@ -9,6 +11,18 @@
  */
 template <typename T>
 T function1(T arg1)
+{}
+
+
+/**
+ * @brief a function with one template argument specialized for `std::string`
+ *
+ * @param arg1 argument of type `std::string`
+ *
+ * @return return value of type `std::string`
+ */
+template <>
+std::string function1<std::string>(std::string arg1)
 {}
 
 


### PR DESCRIPTION
Precisely what the title says. It does so generalizing the regular expression used for function signature parsing in the `doxygenfunction` directive implementation.