### PR TITLE
Handle scoped C++ enums

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -154,9 +154,9 @@ class memberdefTypeSub(supermod.memberdefType):
 
     def __init__(self, initonly=None, kind=None, volatile=None, const=None, raise_=None, virt=None,
                  readable=None, prot=None, explicit=None, new=None, final=None, writable=None,
-                 add=None, static=None, remove=None, sealed=None, mutable=None, gettable=None,
-                 inline=None, settable=None, id=None, templateparamlist=None, type_=None,
-                 definition='', argsstring='', name='', read='', write='', bitfield='',
+                 add=None, static=None, strong=None, remove=None, sealed=None, mutable=None,
+                 gettable=None, inline=None, settable=None, id=None, templateparamlist=None,
+                 type_=None, definition='', argsstring='', name='', read='', write='', bitfield='',
                  reimplements=None, reimplementedby=None, param=None, enumvalue=None,
                  initializer=None, exceptions=None, briefdescription=None, detaileddescription=None,
                  inbodydescription=None, location=None, references=None, referencedby=None,
@@ -164,8 +164,8 @@ class memberdefTypeSub(supermod.memberdefType):
 
         supermod.memberdefType.__init__(self, initonly, kind, volatile, const, raise_, virt,
                                         readable, prot, explicit, new, final, writable, add, static,
-                                        remove, sealed, mutable, gettable, inline, settable, id,
-                                        templateparamlist, type_, definition, argsstring, name,
+                                        strong, remove, sealed, mutable, gettable, inline, settable,
+                                        id, templateparamlist, type_, definition, argsstring, name,
                                         read, write, bitfield, reimplements, reimplementedby, param,
                                         enumvalue, initializer, exceptions, briefdescription,
                                         detaileddescription, inbodydescription, location,

--- a/breathe/parser/compoundsuper.py
+++ b/breathe/parser/compoundsuper.py
@@ -1039,7 +1039,7 @@ class sectiondefType(GeneratedsSuper):
 class memberdefType(GeneratedsSuper):
     subclass = None
     superclass = None
-    def __init__(self, initonly=None, kind=None, volatile=None, const=None, raisexx=None, virt=None, readable=None, prot=None, explicit=None, new=None, final=None, writable=None, add=None, static=None, remove=None, sealed=None, mutable=None, gettable=None, inline=None, settable=None, id=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, param=None, enumvalue=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, refqual=None):
+    def __init__(self, initonly=None, kind=None, volatile=None, const=None, raisexx=None, virt=None, readable=None, prot=None, explicit=None, new=None, final=None, writable=None, add=None, static=None, strong=None, remove=None, sealed=None, mutable=None, gettable=None, inline=None, settable=None, id=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, param=None, enumvalue=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, refqual=None):
         self.initonly = initonly
         self.kind = kind
         self.volatile = volatile
@@ -1054,6 +1054,7 @@ class memberdefType(GeneratedsSuper):
         self.writable = writable
         self.add = add
         self.static = static
+        self.strong = strong
         self.remove = remove
         self.sealed = sealed
         self.mutable = mutable
@@ -1186,6 +1187,8 @@ class memberdefType(GeneratedsSuper):
     def set_add(self, add): self.add = add
     def get_static(self): return self.static
     def set_static(self, static): self.static = static
+    def get_strong(self): return self.strong
+    def set_strong(self, strong): self.strong = strong
     def get_remove(self): return self.remove
     def set_remove(self, remove): self.remove = remove
     def get_sealed(self): return self.sealed
@@ -1263,6 +1266,8 @@ class memberdefType(GeneratedsSuper):
             self.add = attrs.get('add').value
         if attrs.get('static'):
             self.static = attrs.get('static').value
+        if attrs.get('strong'):
+            self.strong = attrs.get('strong').value
         if attrs.get('remove'):
             self.remove = attrs.get('remove').value
         if attrs.get('sealed'):

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -236,6 +236,7 @@ class DomainDirectiveFactory:
         "signal": (CPPFunctionObject, "function"),
         "slot": (CPPFunctionObject, "function"),
         "enum": (CPPEnumObject, "enum"),
+        "enum-class": (CPPEnumObject, "enum-class"),
         "typedef": (CPPTypeObject, "type"),
         "using": (CPPTypeObject, "type"),
         "union": (CPPUnionObject, "union"),
@@ -2002,12 +2003,14 @@ class SphinxRenderer:
             enums = self.render_iterable(node.enumvalue)
             contentnode.extend(enums)
 
-        # TODO: scopedness, Doxygen doesn't seem to generate the xml for that
         # TODO: underlying type, Doxygen doesn't seem to generate the xml for that
         names = self.get_qualification()
         names.append(node.name)
         declaration = self.join_nested_name(names)
-        return self.handle_declaration(node, declaration, content_callback=content)
+        obj_type = "enum-class" if node.strong == "yes" else "enum"
+        return self.handle_declaration(
+            node, declaration, obj_type=obj_type, content_callback=content
+        )
 
     def visit_enumvalue(self, node) -> List[Node]:
         if self.app.config.breathe_show_enumvalue_initializer:  # type: ignore

--- a/examples/doxygen/enum.h
+++ b/examples/doxygen/enum.h
@@ -9,6 +9,12 @@ class Test4
       V1, /*!< value 1 */
       V2  /*!< value 2 */
     };
+
+    enum class AnotherScopedEnum
+    {
+      V1, /*!< value 1 */
+      V2  /*!< value 2 */
+    };
 };
 
 /*! \class Test4


### PR DESCRIPTION
Precisely what the title says. Doxygen does tag scoped enums via the `strong` attribute and this pull request leverages it.