### PR TITLE
admonish \see and \remark cmds

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1546,6 +1546,11 @@ class SphinxRenderer:
             return [nodes.warning("", *nodelist)]
         elif node.kind == "note":
             return [nodes.note("", *nodelist)]
+        elif node.kind == "see":
+            return [addnodes.seealso("", *nodelist)]
+        elif node.kind == "remark":
+            nodelist = [nodes.title("", nodes.Text(node.kind.capitalize()))] + nodelist
+            return [nodes.admonition("", classes=[node.kind], *nodelist)]
 
         if node.kind == "par":
             text = self.render(node.title)


### PR DESCRIPTION
resolves #755

The main goal here is to offer end-users the opportunity to style (with CSS overrides) the `\see`, `\sa`, `\remark`, `\remarks` doxygen cmds. Currently, if users wanted to do this they need an added js to inject classes to html elements which are currently indistinguishable from other XML `simplesection`s (like `\param` and `\return`).

I didn't get any feedback on that issue, so I'm going forward under the assumption that this change is acceptable. See the issue thread for demonstrations.