### PR TITLE
Apply field-list and admonition handling to classes and unions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
     `#749 <https://github.com/michaeljones/breathe/pull/749>`__
   - Make ``.. doxygenfunction`` handle function template specializations.
     `#750 <https://github.com/michaeljones/breathe/pull/750>`__
+  - Properly handle field-lists and admonitions in the detailed description of
+    classes and functions.
+    `#764 <https://github.com/michaeljones/breathe/pull/764>`__
 
 - 2021-09-14 - **Breathe v4.31.0**
 

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -860,6 +860,10 @@ class SphinxRenderer:
 
     def description(self, node) -> List[Node]:
         brief = self.render_optional(node.briefdescription)
+        detailed = self.detaileddescription(node)
+        return brief + detailed
+
+    def detaileddescription(self, node) -> List[Node]:
         detailedCand = self.render_optional(node.detaileddescription)
         # all field_lists must be at the top-level of the desc_content, so pull them up
         fieldLists = []  # type: List[nodes.field_list]
@@ -934,9 +938,9 @@ class SphinxRenderer:
                 fieldLists = [fl]
 
         if self.app.config.breathe_order_parameters_first:  # type: ignore
-            return brief + detailed + fieldLists + admonitions
+            return detailed + fieldLists + admonitions
         else:
-            return brief + detailed + admonitions + fieldLists
+            return detailed + admonitions + fieldLists
 
     def update_signature(self, signature, obj_type):
         """Update the signature node if necessary, e.g. add qualifiers."""
@@ -1300,7 +1304,7 @@ class SphinxRenderer:
 
         if "members-only" not in options:
             addnode("briefdescription", lambda: self.render_optional(node.briefdescription))
-            addnode("detaileddescription", lambda: self.render_optional(node.detaileddescription))
+            addnode("detaileddescription", lambda: self.detaileddescription(node))
 
             def render_derivedcompoundref(node):
                 if node is None:


### PR DESCRIPTION
Most declarations use the ``description()`` method to render the brief and detailed descriptions. That function which pulls up field-lists and admonitions from the detailed description, such that Sphinx can process the field-lists.
But classes and unions render their content through ``visit_compounddef()`` which didn't process the detailed description.
This PR factors out the handling so both methods can apply the handling.
This incidentally also means that classes and unions now get affected by ``breathe_order_parameters_first`` which, despite its name, determines the order between field-lists in general (including template parameter documentation) and admonitions.

Fixes #761.

As test case:
```c++
/// @brief Type
/// @tparam E the type parameter
template<typename E>
using Type = int;

/// @brief Concept
/// @tparam E the type parameter
template<typename E>
concept Concept = true;

/// @brief Var
/// @tparam E the type parameter
template<typename E>
int Var = 42;

/// @brief Function
/// @tparam E the type parameter
template<typename E>
void Function() {}

/// @brief Class
/// @tparam E the type parameter
template<typename E>
class Class {};

/// @brief Union
/// @tparam E the type parameter
template<typename E>
union Union { int i; };
```
The concept declaration seems to no be handled correctly by Doxygen, so it should be checked at a later stage.