### PR TITLE
Update Sphinx and Python versions tested against

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         sphinx-version:
           - 3.0.4
           - 3.1.2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         sphinx-version:
           - 3.0.4
           - 3.1.2
@@ -16,7 +16,9 @@ jobs:
           - 3.5.4
           - 4.0.3
           - 4.1.2
-          - git+https://github.com/sphinx-doc/sphinx.git@4.2.x
+          - 4.2.0
+          - 4.3.0
+          - git+https://github.com/sphinx-doc/sphinx.git@4.3.x
           - git+https://github.com/sphinx-doc/sphinx.git@4.x
           - git+https://github.com/sphinx-doc/sphinx.git@master
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,22 +5,34 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         sphinx-version:
-          - 3.0.4
-          - 3.1.2
-          - 3.2.1
-          - 3.3.1
-          - 3.4.3
-          - 3.5.4
-          - 4.0.3
-          - 4.1.2
-          - 4.2.0
-          - 4.3.0
+          - '3.0.4'
+          - '3.1.2'
+          - '3.2.1'
+          - '3.3.1'
+          - '3.4.3'
+          - '3.5.4'
+          - '4.0.3'
+          - '4.1.2'
+          - '4.2.0'
+          - '4.3.0'
           - git+https://github.com/sphinx-doc/sphinx.git@4.3.x
           - git+https://github.com/sphinx-doc/sphinx.git@4.x
           - git+https://github.com/sphinx-doc/sphinx.git@master
+        # avoid bug in following configurations
+        # sphinx/util/typing.py:37: in <module>
+        #     from types import Union as types_Union
+        # ImportError: cannot import name 'Union' from 'types'
+        exclude:
+          - python-version: '3.10'
+            sphinx-version: '3.5.4'
+          - python-version: '3.10'
+            sphinx-version: '4.0.3'
+          - python-version: '3.10'
+            sphinx-version: '4.1.2'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update Sphinx versions tests against after recent release.
Also add Python 3.10 to the test matrix.
And apply the CI changes from @2bndy5 in #763.