### PR TITLE
Use setuptools_scm to package version number into metadata

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip install -r requirements/development.txt
+          pip install . -r requirements/development.txt
           sudo apt -y install doxygen
 
       - name: build the documentation

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 /breathe.egg-info
 /.mypy_cache
 
+# this is generated at build-time by setuptools_scm
+breathe/version.py
+
 # Folder for placing stuff to be ignored
 /ignored
 

--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -4,7 +4,10 @@ from breathe.renderer.sphinxrenderer import setup as renderer_setup
 
 from sphinx.application import Sphinx
 
-__version__ = "4.31.0"
+try:
+    from importlib.metadata import version
+except ImportError:  # for python v3.7 or older
+    from importlib_metadata import version  # type: ignore
 
 
 def setup(app: Sphinx):
@@ -12,4 +15,4 @@ def setup(app: Sphinx):
     file_state_cache_setup(app)
     renderer_setup(app)
 
-    return {"version": __version__, "parallel_read_safe": True, "parallel_write_safe": True}
+    return {"version": version("breathe"), "parallel_read_safe": True, "parallel_write_safe": True}

--- a/breathe/apidoc.py
+++ b/breathe/apidoc.py
@@ -22,7 +22,11 @@ import argparse
 import errno
 import xml.etree.ElementTree
 
-from breathe import __version__
+try:
+    from importlib.metadata import version
+except ImportError:  # for python v3.7 or older
+    from importlib_metadata import version  # type: ignore
+
 
 # Account for FileNotFoundError in Python 2
 # IOError is broader but will hopefully suffice
@@ -222,7 +226,7 @@ Note: By default this script will not overwrite already created files.""",
         "-q", "--quiet", action="store_true", dest="quiet", help="suppress informational messages"
     )
     parser.add_argument(
-        "--version", action="version", version="Breathe (breathe-apidoc) %s" % __version__
+        "--version", action="version", version="Breathe (breathe-apidoc) %s" % version("breathe")
     )
     parser.add_argument("rootpath", type=str, help="The directory contains index.xml")
     args = parser.parse_args()

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -19,6 +19,12 @@ import os
 import subprocess
 import re
 
+try:
+    from importlib.metadata import version as get_version
+except ImportError:  # for python v3.7 or older
+    from importlib_metadata import version as get_version  # type: ignore
+
+
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
@@ -32,74 +38,44 @@ import re
 extensions = ["breathe", "sphinx.ext.mathjax", "sphinx.ext.ifconfig"]
 
 read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
-travis_build = os.environ.get("TRAVIS_CI", None) == "True"
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = "'unknown'"
+# The full version, including alpha/beta/rc tags.
+release = "'unknown'"
 
 # Get a description of the current position. Use Popen for 2.6 compat
-git_tag = subprocess.Popen(["git", "describe", "--tags"], stdout=subprocess.PIPE).communicate()[0]
+git_tag = get_version("breathe")
 
-# convert from bytes to string
-git_tag = git_tag.decode("ascii")
-
-if travis_build:
-
-    # Don't attempt to set the path as breathe is installed to virtualenv on travis
-
-    # Set values with simple strings
-    version = "'travis'"
-    release = "'travis'"
-    documentation_build = "travis"
-
-elif read_the_docs_build:
-
-    # On RTD we'll be in the 'source' directory
-    sys.path.append("../../")
-
-    # The version info for the project you're documenting, acts as replacement for
-    # |version| and |release|, also used in various other places throughout the
-    # built documents.
-    #
-    # The short X.Y version.
-    version = "'unknown'"
-    # The full version, including alpha/beta/rc tags.
-    release = "'unknown'"
-
-    # Check if it matches a pure tag number vX.Y.Z, rather than vX.Y.Z-91-g8676988 which is how
-    # non-tagged commits are described (ie. relative to the last tag)
-    if re.match(r"^v\d+\.\d+\.\d+$", git_tag):
-        # git_tag is a pure version number (no subsequent commits)
-        version = git_tag
-        release = git_tag
-        documentation_build = "readthedocs"
-
-    else:
-        version = "'latest'"
-        release = "'latest'"
-        documentation_build = "readthedocs_latest"
-
+# Check if it matches a pure tag number vX.Y.Z, rather than vX.Y.Z-91-g8676988 which is how
+# non-tagged commits are described (ie. relative to the last tag)
+if re.match(r"^\d+\.\d+\.\d+$", git_tag):
+    # git_tag is a pure version number (no subsequent commits)
+    version = "v" + git_tag
+    release = "v" + git_tag
 else:
+    version = "'latest'"
+    release = "'latest'"
 
-    # For our usual dev build we'll be in the 'documentation' directory but Sphinx seems to set the
-    # current working directory to 'source' so we append relative to that
-    sys.path.append("../../")
+# For our usual dev build (& on RTD) we'll be in the 'documentation' directory but Sphinx seems to
+# set the current working directory to 'source' so we append relative to that
+sys.path.append("../../")
 
-    # Check if it matches a pure tag number vX.Y.Z, rather than vX.Y.Z-91-g8676988 which is how
-    # non-tagged commits are described (ie. relative to the last tag)
-    if re.match(r"^v\d+\.\d+\.\d+$", git_tag):
-        # git_tag is a pure version number (no subsequent commits)
-        version = git_tag
-        release = git_tag
+if read_the_docs_build:
+    if version != "'latest'":
+        documentation_build = "readthedocs"
     else:
-        version = "'latest'"
-        release = "'latest'"
-
+        documentation_build = "readthedocs_latest"
+else:
     documentation_build = "development"
-
 
 # If we're doing a comparison then set the version & release to 'compare' so that they are always
 # the same otherwise they can come up as changes when we really don't care if they are different.
-comparison = os.environ.get("BREATHE_COMPARE", None) == "True"
-
-if comparison:
+if os.environ.get("BREATHE_COMPARE", "False").capitalize() == "True":
     version = "compare"
     release = "compare"
 
@@ -125,9 +101,7 @@ spelling_lang = "en_US"
 # Set path for mathjax js to a https URL as sometimes the Breathe docs are displayed under https
 # and we can't load an http mathjax file from an https view of the docs. So we change to a https
 # mathjax file which we can load from http or https. We break the url over two lines.
-mathjax_path = (
-    "https://c328740.ssl.cf1.rackcdn.com/" "mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-)
+mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -48,7 +48,7 @@ version = "'unknown'"
 # The full version, including alpha/beta/rc tags.
 release = "'unknown'"
 
-# Get a description of the current position. Use Popen for 2.6 compat
+# Get a description of the current version.
 git_tag = get_version("breathe")
 
 # Check if it matches a pure tag number vX.Y.Z, rather than vX.Y.Z-91-g8676988 which is how

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,14 @@ line-length = 100
 extend-exclude = '''
 ^/breathe/parser/.*
 '''
+
+[build-system]
+requires = [
+    "setuptools>=45",
+    "wheel",
+    "setuptools_scm>=6.2",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "breathe/version.py"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ except ImportError:
     from setuptools import setup, find_packages
 
 import sys
-from breathe import __version__
 
 long_desc = """
 Breathe is an extension to reStructuredText and Sphinx to be able to read and
@@ -24,7 +23,6 @@ if sys.version_info < (3, 6):
 
 setup(
     name="breathe",
-    version=__version__,
     url="https://github.com/michaeljones/breathe",
     download_url="https://github.com/michaeljones/breathe",
     license="BSD",


### PR DESCRIPTION
resolves #714 and closes #746

[setuptools_scm repo](https://github.com/pypa/setuptools_scm) (for reference)
[python docs on importlib.metadata module](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata) as that is now the preferred implementation to get version info for a specified (& installed) package.

This replaces the need to store the version number in the package's \_\_init\_\_.py module. Instead the version information can be found within the installed package metadata (as recommended by [PEP 440](https://www.python.org/dev/peps/pep-0440/)). I've additionally configured the setuptools_scm module to generate a _version.py_ file in the breathe folder for distibution.

This switch also reduces the need to use `git describe` in the docs' _conf.py_ to get the git tag. Thus, I've simplified that process as well. While I was in the conf.py file, I noticed that the `mathjax_path` option was outdated (per [info in sphinx-docs](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#confval-mathjax_path)), so I updated that as well. See the docs' CI artifact to verify math formulas are correctly rendered (as I have already done locally).