### PR TITLE
Fix friend functions for older Doxygen versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
   - Add :confval:`breathe_show_include` to control whether ``#include`` lines
     are shown. Defaults to ``True``.
     `#725 <https://github.com/michaeljones/breathe/pull/725>`__
+  - Fix friend functions for older Doxygen versions.
+    `#767 <https://github.com/michaeljones/breathe/issues/767>`__
 
 - 2021-09-14 - **Breathe v4.31.0**
 

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1923,6 +1923,11 @@ class SphinxRenderer:
                 # Doxygen sometimes leaves 'static' in the type,
                 # e.g., for "constexpr static auto f()"
                 typ = typ.replace("static ", "")
+                # In Doxygen up to somewhere between 1.8.17 to exclusive 1.9.1
+                # the 'friend' part is also left in the type.
+                # See also #767.
+                if typ.startswith("friend "):
+                    typ = typ[7:]
                 elements.append(typ)
                 elements.append(name)
                 elements.append(node.get_argsstring())


### PR DESCRIPTION
Fixes #767.

The problem is present with Doxygen 1.8.17 (default version in Ubuntu 20.04) but not in 1.9.1.