### PR TITLE
Refactor directive addition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
     `#767 <https://github.com/michaeljones/breathe/issues/767>`__
   - Doxygen >= 1.9.2 supports C++20 concepts, add support for them.
     `#779 <https://github.com/michaeljones/breathe/pull/779>`__
+  - Change the way directives are added to adhere to the interface,
+    e.g., avoiding myst-parser to crash.
+    `#780 <https://github.com/michaeljones/breathe/pull/780>`__
 
 - 2021-09-14 - **Breathe v4.31.0**
 

--- a/breathe/directives/__init__.py
+++ b/breathe/directives/__init__.py
@@ -41,26 +41,36 @@ class _WarningHandler:
 
 
 class BaseDirective(SphinxDirective):
-    required_arguments: int
-    optional_arguments: int
-    option_spec: Dict[str, Any]
-    has_content: bool
-    final_argument_whitespace: bool
+    @property
+    def directive_args(self) -> list:
+        # the order must be the same as in docutils.parsers.rst.Directive.__init__
+        return [
+            self.name,
+            self.arguments,
+            self.options,
+            self.content,
+            self.lineno,
+            self.content_offset,
+            self.block_text,
+            self.state,
+            self.state_machine,
+        ]
 
-    def __init__(
-        self,
-        finder_factory: FinderFactory,
-        project_info_factory: ProjectInfoFactory,
-        parser_factory: DoxygenParserFactory,
-        *args
-    ) -> None:
-        super().__init__(*args)
-        self.directive_args = list(args)  # Convert tuple to list to allow modification.
+    @property
+    def project_info_factory(self) -> ProjectInfoFactory:
+        return self.env.temp_data["breathe_project_info_factory"]
 
-        self.finder_factory = finder_factory
-        self.project_info_factory = project_info_factory
-        self.filter_factory = FilterFactory(self.env.app)
-        self.parser_factory = parser_factory
+    @property
+    def parser_factory(self) -> DoxygenParserFactory:
+        return self.env.temp_data["breathe_parser_factory"]
+
+    @property
+    def finder_factory(self) -> FinderFactory:
+        return FinderFactory(self.env.app, self.parser_factory)
+
+    @property
+    def filter_factory(self) -> FilterFactory:
+        return FilterFactory(self.env.app)
 
     @property
     def kind(self) -> str:

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -111,9 +111,14 @@ class WrappedCompoundDef(compounddefTypeSub, WrappedDoxygenNode):
 
 class MockState:
     def __init__(self, app):
+        from breathe.project import ProjectInfoFactory
+        from breathe.parser import DoxygenParserFactory
+
         env = sphinx.environment.BuildEnvironment(app)
         env.setup(app)
         env.temp_data["docname"] = "mock-doc"
+        env.temp_data["breathe_project_info_factory"] = ProjectInfoFactory(app)
+        env.temp_data["breathe_parser_factory"] = DoxygenParserFactory(app)
         settings = frontend.OptionParser(components=(parsers.rst.Parser,)).get_default_values()
         settings.env = env
         self.document = utils.new_document("", settings)
@@ -516,9 +521,6 @@ def test_render_innergroup(app):
 
 def get_directive(app):
     from breathe.directives.function import DoxygenFunctionDirective
-    from breathe.project import ProjectInfoFactory
-    from breathe.parser import DoxygenParserFactory
-    from breathe.finder.factory import FinderFactory
     from docutils.statemachine import StringList
 
     app.config.breathe_separate_member_pages = False
@@ -526,9 +528,6 @@ def get_directive(app):
     app.config.breathe_domain_by_extension = {}
     app.config.breathe_domain_by_file_pattern = {}
     app.config.breathe_use_project_refids = False
-    project_info_factory = ProjectInfoFactory(app)
-    parser_factory = DoxygenParserFactory(app)
-    finder_factory = FinderFactory(app, parser_factory)
     cls_args = (
         "doxygenclass",
         ["at::Tensor"],
@@ -543,7 +542,7 @@ def get_directive(app):
         MockState(app),
         MockStateMachine(),
     )
-    return DoxygenFunctionDirective(finder_factory, project_info_factory, parser_factory, *cls_args)
+    return DoxygenFunctionDirective(*cls_args)
 
 
 def get_matches(datafile):


### PR DESCRIPTION
Based on #775 it turns out that they way Breathe uses ``add_directive`` is not strictly adhering to the interface: the argument must be a class derived from ``docutils.parsers.rst.Directive`` (https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_directive).
This was not done because the Breathe directives needs access to some objects created during setup-time.
This PR uses a different hax: use ``env.temp_data`` to smuggle in those objects, and set them every time a new document is processed, via the ``source-read`` event. Thereby the directives can be added directly.

It's still ugly but I haven't found a prettier way to do it.

References:
- https://github.com/executablebooks/MyST-Parser/issues/460#issuecomment-990992776
- Fixes https://github.com/executablebooks/MyST-Parser/issues/322
- Fixes https://github.com/executablebooks/MyST-Parser/issues/323