### PR TITLE
Store version number in both setup.py & __init__.py

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: type check the source code
         run: make type-check
+
+      - name: check version numbers are in sync
+        run: make version-check

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,7 @@ black:
 .PHONY: type-check
 type-check:
 	mypy --warn-redundant-casts --warn-unused-ignores breathe tests
+
+.PHONY: version-check
+version-check:
+	 python3 scripts/version-check.py

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ type-check:
 
 .PHONY: version-check
 version-check:
-	 python3 scripts/version-check.py
+	 PYTHONPATH=../:$(PYTHONPATH) python3 scripts/version-check.py

--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -7,6 +7,7 @@ from sphinx.application import Sphinx
 # Keep in sync with setup.py __version__
 __version__ = "4.31.0"
 
+
 def setup(app: Sphinx):
     directive_setup(app)
     file_state_cache_setup(app)

--- a/breathe/__init__.py
+++ b/breathe/__init__.py
@@ -4,8 +4,8 @@ from breathe.renderer.sphinxrenderer import setup as renderer_setup
 
 from sphinx.application import Sphinx
 
+# Keep in sync with setup.py __version__
 __version__ = "4.31.0"
-
 
 def setup(app: Sphinx):
     directive_setup(app)

--- a/scripts/version-check.py
+++ b/scripts/version-check.py
@@ -9,9 +9,9 @@ import re
 import breathe
 
 setup_version = ""
-with open('setup.py') as setup:
+with open("setup.py") as setup:
     for line in setup:
-        if line.startswith('__version__'):
+        if line.startswith("__version__"):
             match = re.search('"(?P<version>[^"]*)"', line)
             if match:
                 setup_version = match.group("version")

--- a/scripts/version-check.py
+++ b/scripts/version-check.py
@@ -1,0 +1,28 @@
+"""
+This script is designed to check that the version numbers that we have in place stay in sync. The
+script fails with exit code 1 if they are not the same and always prints the current status.
+"""
+
+import sys
+import re
+
+import breathe
+
+setup_version = ""
+with open('setup.py') as setup:
+    for line in setup:
+        if line.startswith('__version__'):
+            match = re.search('"(?P<version>[^"]*)"', line)
+            if match:
+                setup_version = match.group("version")
+
+if setup_version == breathe.__version__:
+    print("Versions match")
+    print(f"  {setup_version}")
+    print(f"  {breathe.__version__}")
+    sys.exit(0)
+else:
+    print("Versions do not match")
+    print(f"  {setup_version}")
+    print(f"  {breathe.__version__}")
+    sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ except ImportError:
     from setuptools import setup, find_packages
 
 import sys
-from breathe import __version__
+
+# Keep in sync with breathe/__init__.py __version__
+__version__ = "4.31.0"
 
 long_desc = """
 Breathe is an extension to reStructuredText and Sphinx to be able to read and


### PR DESCRIPTION
*The PR has changed a bit. Title updated to reflect that but not the text immediately below.*

So that we can import it cleanly without importing the whole package and
all of sphinx which some environments don't have for some of the stages
that they run.

This is a naive and uninformed attempt to solve some of our current issues. I'm very out of touch with python packaging and the best way to handle this but for the moment our readthedocs builds are failing (https://readthedocs.org/projects/breathe/builds/15850101/) because they don't have `sphinx` available when the `setup.py` code is trying to access `breathe.__version__` and it would be good to get them passing again.

Failure stacktrace:
```
    File "/tmp/pip-build-env-oli4rdc4/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 11, in <module>
      from breathe import __version__
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/checkouts/latest/breathe/__init__.py", line 1, in <module>
      from breathe.directives.setup import setup as directive_setup
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/checkouts/latest/breathe/directives/__init__.py", line 1, in <module>
      from breathe.finder.factory import FinderFactory
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/checkouts/latest/breathe/finder/__init__.py", line 1, in <module>
      from breathe.project import ProjectInfo
    File "/home/docs/checkouts/readthedocs.org/user_builds/breathe/checkouts/latest/breathe/project.py", line 3, in <module>
      from sphinx.application import Sphinx
  ModuleNotFoundError: No module named 'sphinx'
```