### PR TITLE
Remove extra 'static' on variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Change Log
 
 Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
 
+- Unreleased - **Breathe v4.33.0**
+
+  - Fix duplicate ``static`` in variable declarations.
+    `#794 <https://github.com/michaeljones/breathe/pull/794>`__
+
 - 2022-01-30 - **Breathe v4.32.0**
 
   - Added ``breathe_doxygen_aliases`` config variable.

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -2124,6 +2124,9 @@ class SphinxRenderer:
             if node.mutable == "yes":
                 elements.append("mutable")
             typename = "".join(n.astext() for n in self.render(node.get_type()))
+            # Doxygen sometimes leaves 'static' in the type,
+            # e.g., for "constexpr static int i"
+            typename = typename.replace("static ", "")
             if dom == "c" and "::" in typename:
                 typename = typename.replace("::", ".")
             elements.append(typename)

--- a/examples/specific/cpp_constexpr_hax.h
+++ b/examples/specific/cpp_constexpr_hax.h
@@ -1,2 +1,5 @@
 [[nodiscard]] constexpr static auto f1(std::false_type) {}
 [[nodiscard]] static constexpr auto f2(std::false_type) {}
+
+constexpr static int v1 = 42;
+static constexpr int v2 = 42;


### PR DESCRIPTION
Fixes #787. Similar hax as in #720, just now for variables.