### PR TITLE
Remove python 3.6 from testing matrix

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         sphinx-version:
           - '3.0.4'
           - '3.1.2'


### PR DESCRIPTION
It has been end-of-lifed as of 2021-12-23.

Does this seem reasonable? I don't know if we're somehow in the game of supporting older platforms? I suspect 2.7 has been given a long life for various reasons but there is less reason for Linux distributions, etc, to support 3.6 beyond its end.

https://www.python.org/dev/peps/pep-0494/#lifespan