### PR TITLE
treat .unparsed as plain text

### DIFF
--- a/breathe/filetypes.py
+++ b/breathe/filetypes.py
@@ -18,4 +18,4 @@ def get_extension(filename: str) -> str:
     # If the filename is just '.ext' then we get ('.ext', '') so we fall back to first part if
     # the second isn't there
     (first, second) = os.path.splitext(filename)
-    return (second or first).lstrip(".")
+    return (second or first).lstrip(".").replace("unparsed", "text")

--- a/breathe/filetypes.py
+++ b/breathe/filetypes.py
@@ -18,4 +18,7 @@ def get_extension(filename: str) -> str:
     # If the filename is just '.ext' then we get ('.ext', '') so we fall back to first part if
     # the second isn't there
     (first, second) = os.path.splitext(filename)
+
+    # Doxygen allows users to specify the file extension ".unparsed" to disable syntax highlighting.
+    # We translate it into the pygments unhighlighted 'text' type
     return (second or first).lstrip(".").replace("unparsed", "text")

--- a/documentation/source/codeblocks.rst
+++ b/documentation/source/codeblocks.rst
@@ -91,6 +91,11 @@ recognize the code block's contained syntax as a C++ snippet.
     *     message(STATUS "Element is ${element}")
     * endforeach()
     * @endcode
+    * 
+    * Another code-block that explicitly remains not highlighted.
+    * @code{.unparsed}
+    * Show this as is.
+    * @endcode
     */
    void with_unannotated_cmake_code_block();
 

--- a/examples/specific/code_blocks.h
+++ b/examples/specific/code_blocks.h
@@ -16,6 +16,11 @@ void with_standard_code_block();
  *     message(STATUS "Element is ${element}")
  * endforeach()
  * @endcode
+ * 
+ * Another code-block that explicitly remains not highlighted.
+ * @code{.unparsed}
+ * Show this as is.
+ * @endcode
  */
 void with_unannotated_cmake_code_block();
 


### PR DESCRIPTION
This fixes #805. 

[According to the doxygen manual](https://www.doxygen.nl/manual/commands.html#cmdcode), users can specify a file extension called .unparsed to disable syntax highlighting. Since this isn't a real language that pygments supports, there was a warning generated when users followed the doxygen manual.

This is a simple patch that replaces the "unparsed" file extension with "text" to invoke [pygments' null highlighting lexer](https://pygments.org/docs/lexers/#pygments.lexers.special.TextLexer).

I also added a code block (that uses `\code{.unparsed}`) to the doc's example snippets in the _codeblocks.rst_ (and _examples/specific/code_blocks.h_) to verify this warning is properly suppressed.