### PR TITLE
Make NodeFinder actually do sparse visitation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Change Log
 
 Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
 
+- Unreleased
+
+  - Fix internal ``NodeFinder`` visitor for when non-Docutils nodes are
+    present in the content of a directive.
+    `#812 <https://github.com/michaeljones/breathe/pull/812>`__
+
 - 2022-02-14 - **Breathe v4.33.1**
 
   - Avoid warning about multiple graphviz directives.

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -359,6 +359,12 @@ class NodeFinder(nodes.SparseNodeVisitor):
 
     def visit_desc_content(self, node):
         self.content = node
+        # The SparseNodeVisitor seems to not actually be universally Sparse,
+        # but only for nodes known to Docutils.
+        # So if there are extensions with new node types in the content,
+        # then the visitation will fail.
+        # We anyway don't need to visit the actual content, so skip it.
+        raise nodes.SkipChildren
 
 
 def intersperse(iterable, delimiter):


### PR DESCRIPTION
It seems that the Docutils ``node.SparseNodeVisitor`` is not actually that sparse, so skip subtrees explicitly.

Fixes michaeljones/breathe#807.