### PR TITLE
Type check pygments and limit docutils stub version

### DIFF
--- a/breathe/filetypes.py
+++ b/breathe/filetypes.py
@@ -1,15 +1,20 @@
+"""
+A module to house the methods for resolving a code-blocks language based on filename
+(and extension).
+"""
 from typing import Optional
 import os.path
 
-import pygments  # type: ignore
+from pygments.lexers import get_lexer_for_filename
+from pygments.util import ClassNotFound
 
 
 def get_pygments_alias(filename: str) -> Optional[str]:
     "Find first pygments alias from filename"
     try:
-        lexer_cls = pygments.lexers.get_lexer_for_filename(filename)
-        return lexer_cls.aliases[0]
-    except pygments.util.ClassNotFound:
+        lexer_cls = get_lexer_for_filename(filename)
+        return lexer_cls.aliases[0]  # type: ignore
+    except ClassNotFound:
         return None
 
 
@@ -20,5 +25,5 @@ def get_extension(filename: str) -> str:
     (first, second) = os.path.splitext(filename)
 
     # Doxygen allows users to specify the file extension ".unparsed" to disable syntax highlighting.
-    # We translate it into the pygments unhighlighted 'text' type
+    # We translate it into the pygments un-highlighted 'text' type
     return (second or first).lstrip(".").replace("unparsed", "text")

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -15,7 +15,7 @@ from sphinx.util import url_re
 from sphinx.ext.graphviz import graphviz
 
 from docutils import nodes
-from docutils.nodes import Element, Node, TextElement
+from docutils.nodes import Node, TextElement
 from docutils.statemachine import StringList, UnexpectedIndentationError
 from docutils.parsers.rst.states import Text
 
@@ -846,7 +846,7 @@ class SphinxRenderer:
             signode.children = [n for n in signode.children if not n.tagname == "desc_addname"]
         return nodes
 
-    def create_doxygen_target(self, node) -> List[Element]:
+    def create_doxygen_target(self, node):
         """Can be overridden to create a target node which uses the doxygen refid information
         which can be used for creating links between internal doxygen elements.
 

--- a/breathe/renderer/target.py
+++ b/breathe/renderer/target.py
@@ -3,11 +3,11 @@ from breathe.project import ProjectInfo
 from docutils import nodes
 from docutils.nodes import Element
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
 
 
 class TargetHandler:
-    def create_target(self, refid: str) -> List[Element]:
+    def create_target(self, refid: str) -> Sequence[Element]:
         raise NotImplementedError
 
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -5,7 +5,7 @@ pip-tools>=0.3.5
 pytest
 
 mypy>=0.900
-types-docutils>=0.17.0
+types-docutils>=0.14,<0.18
 types-Pygments
 
 black==22.1.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,5 +6,6 @@ pytest
 
 mypy>=0.900
 types-docutils>=0.17.0
+types-Pygments
 
 black==22.1.0


### PR DESCRIPTION
1. Add the capability to type check Pygments API (mostly).
2. Conforms the `types-docutils` stub version to the sphinx requirements. This change is meant to satisfy the following observation:

   After researching the mypy errors a bit, sphinx currently mandates that `docutils>=0.14,<0.18` while the CI is installing 0.17.1. The `types-docutils>=0.17.0` in (requirements/development.txt) leads to mypy using a stubs for 0.18.0 of docutils. Note that breathe also specifies `docutils>=0.12` in requirements/production.txt.

  Notice that I have not altered breathe's requirements (in requirements/production.txt) - only the stubs in requirements/development.txt.