### PR TITLE
convert dot files' relative path to absolute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ com_crashlytics_export_strings.xml
 
 # modified by build process
 examples/doxygen/example.tag
+examples/specific/dot_graphs/xml/dotfile.dot

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1,3 +1,4 @@
+import os
 import sphinx
 
 from breathe.parser import compound, compoundsuper, DoxygenCompoundParser
@@ -2369,11 +2370,22 @@ class SphinxRenderer:
     def visit_docdotfile(self, node) -> List[Node]:
         """Translate node from doxygen's dotfile command to sphinx's graphviz directive."""
         dotcode = ""
+        dot_file_path = node.name  # type: str
+        # Doxygen v1.9.3+ uses a relative path to specify the dot file.
+        # Previously, Doxygen used an absolute path.
+        # This relative path is with respect to the XML_OUTPUT path.
+        # furthermore, Doxygen v1.9.3+ will copy the dot file into the XML_OUTPUT
+        if not os.path.isabs(dot_file_path):
+            # use self.project_info.project_path as the XML_OUTPUT path,
+            # and make it absolute with consideration to the conf.py path
+            dot_file_path = os.path.abspath(
+                self.app.confdir + os.sep + self.project_info.project_path() + dot_file_path
+            )
         try:
-            with open(node.name, encoding="utf-8") as fp:
+            with open(dot_file_path, encoding="utf-8") as fp:
                 dotcode = fp.read()
             if not dotcode.rstrip("\n"):
-                raise RuntimeError("%s found but without any content" % node.name)
+                raise RuntimeError("%s found but without any content" % dot_file_path)
         except OSError as exc:
             # doxygen seems to prevent this from triggering as a non-existant file
             # generates no XML output for the corresponding `\dotfile` cmd
@@ -2382,7 +2394,7 @@ class SphinxRenderer:
             self.state.document.reporter.warning(exc)
         graph_node = graphviz()
         graph_node["code"] = dotcode
-        graph_node["options"] = {"docname": node.name}
+        graph_node["options"] = {"docname": dot_file_path}
         caption = "" if not node.content_ else node.content_[0].getValue()
         if caption:
             caption_node = nodes.caption(caption, "")

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -2374,13 +2374,17 @@ class SphinxRenderer:
         # Doxygen v1.9.3+ uses a relative path to specify the dot file.
         # Previously, Doxygen used an absolute path.
         # This relative path is with respect to the XML_OUTPUT path.
-        # furthermore, Doxygen v1.9.3+ will copy the dot file into the XML_OUTPUT
+        # Furthermore, Doxygen v1.9.3+ will copy the dot file into the XML_OUTPUT
         if not os.path.isabs(dot_file_path):
-            # use self.project_info.project_path as the XML_OUTPUT path,
-            # and make it absolute with consideration to the conf.py path
-            dot_file_path = os.path.abspath(
-                self.app.confdir + os.sep + self.project_info.project_path() + dot_file_path
-            )
+            # Use self.project_info.project_path as the XML_OUTPUT path, and
+            # make it absolute with consideration to the conf.py path
+            project_path = self.project_info.project_path()
+            if os.path.isabs(project_path):
+                dot_file_path = os.path.abspath(project_path + os.sep + dot_file_path)
+            else:
+                dot_file_path = os.path.abspath(
+                    self.app.confdir + os.sep + project_path + os.sep + dot_file_path
+                )
         try:
             with open(dot_file_path, encoding="utf-8") as fp:
                 dotcode = fp.read()


### PR DESCRIPTION
This PR will resolve #818 

Add generated examples/specific/dot_graphs/xml/dotfile.dot to gitignore since doxygen 1.9.3 now copies the dotfile(s) to XML_OUTPUT

Considering the path to conf.py, make a dot file's relative path absolute using the project's XML_OUTPUT.

### Notes
This PR's CI is still using Doxygen v1.8.17 (which uses absolute paths for dot files), but I have locally tested these changes using Doxygen v1.9.3 (which introduced using relative paths for dot files). Therefore, backward compatibility is preserved.