### PR TITLE
CI, update Sphinx versions to test

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,12 +9,6 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         sphinx-version:
-          - '3.0.4'
-          - '3.1.2'
-          - '3.2.1'
-          - '3.3.1'
-          - '3.4.3'
-          - '3.5.4'
           - '4.0.3'
           - '4.1.2'
           - '4.2.0'
@@ -29,8 +23,6 @@ jobs:
         #     from types import Union as types_Union
         # ImportError: cannot import name 'Union' from 'types'
         exclude:
-          - python-version: '3.10'
-            sphinx-version: '3.5.4'
           - python-version: '3.10'
             sphinx-version: '4.0.3'
           - python-version: '3.10'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,8 +14,8 @@ jobs:
           - '4.2.0'
           - '4.3.2'
           - '4.5.0'
-          - git+https://github.com/sphinx-doc/sphinx.git@4.5.x
-          - git+https://github.com/sphinx-doc/sphinx.git@4.x
+          - '5.0.0'
+          - git+https://github.com/sphinx-doc/sphinx.git@5.0.x
           - git+https://github.com/sphinx-doc/sphinx.git@5.x
           - git+https://github.com/sphinx-doc/sphinx.git@master
         # avoid bug in following configurations

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,9 +19,10 @@ jobs:
           - '4.1.2'
           - '4.2.0'
           - '4.3.2'
-          - '4.4.0'
-          - git+https://github.com/sphinx-doc/sphinx.git@4.4.x
+          - '4.5.0'
+          - git+https://github.com/sphinx-doc/sphinx.git@4.5.x
           - git+https://github.com/sphinx-doc/sphinx.git@4.x
+          - git+https://github.com/sphinx-doc/sphinx.git@5.x
           - git+https://github.com/sphinx-doc/sphinx.git@master
         # avoid bug in following configurations
         # sphinx/util/typing.py:37: in <module>

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ branch.
 Requirements
 ------------
 
-Breathe requires Python 3.6+, Sphinx 3.0+ and Doxygen 1.8+.
+Breathe requires Python 3.6+, Sphinx 4.0+ and Doxygen 1.8+.
 
 Mailing List Archives
 ---------------------

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,4 +8,4 @@ mypy>=0.900
 types-docutils>=0.14,<0.18
 types-Pygments
 
-black==22.1.0
+black==22.3.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,4 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=4.0,<6
+Sphinx>=4.0,<6,!=5.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,4 @@ docutils>=0.12
 Jinja2>=2.7.3
 MarkupSafe>=0.23
 Pygments>=1.6
-Sphinx>=3.0,<5
+Sphinx>=4.0,<6


### PR DESCRIPTION
- Update due to Sphinx 5 release.
- Also, update Black to avoid a bug in that package.
- And stop testing against Sphinx 3 versions due to incompatibility with newer Jinja 2 versions.
- Require Sphinx >= 4, and allow 5