### PR TITLE
Fixing inconsistency in example

### DIFF
--- a/examples/doxygen/example_test.cpp
+++ b/examples/doxygen/example_test.cpp
@@ -1,5 +1,5 @@
 void main()
 {
-  Test7 t;
+  Test5 t;
   t.example();
 }


### PR DESCRIPTION
The example code is described as "This is an example of how to use the Test5 class", but actually the class "Test7" was used in the example code.