### PR TITLE
Fix error when using Sphinx renderer with C# enums

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -295,6 +295,7 @@ class DomainDirectiveFactory:
             "variable": (CSharpVariable, "var"),
             "property": (CSharpProperty, "property"),
             "event": (CSharpEvent, "event"),
+            "enum-class": (CSharpEnum, "enum"),
             "enum": (CSharpEnum, "enum"),
             "enumvalue": (CSharpEnumValue, "enumerator"),
             "attribute": (CSharpAttribute, "attr"),


### PR DESCRIPTION
Fixes #847

The error appears to be related to Doxygen applying `strong="yes"` to the enums' `memberdef` tags in the XML, as seen in the example input [here](https://gist.github.com/Esvandiary/91a203ff03f371a420838a76ce907d1f). This results in the Sphinx renderer marking their object type as `enum-class` rather than `enum`; however, there is no `enum-class` object type defined in the C# type mapping, so an exception occurs.

This PR takes the route of defining `enum-class` in the C# type mapping with an identical definition to `enum`; this seems like the least disruptive option, but I don't know if a different solution (e.g. checking if we're generating for C# when deciding the object type and not using the `enum-class` type if so) would be preferred.