### PR TITLE
Drop Sphinx 3, add Sphinx 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
  render `Doxygen <http://www.doxygen.org>`__ xml output.
 """
 
-requires = ["Sphinx>=3.0,<5", "docutils>=0.12"]
+requires = ["Sphinx>=4.0,<6,!=5.0.0", "docutils>=0.12"]
 
 if sys.version_info < (3, 6):
     print("ERROR: Sphinx requires at least Python 3.6 to run.")


### PR DESCRIPTION
Updating setup.py to reflect changes to ci and requirements files. It would be great if you could merge this and make a new release soon.

The upper pin to sphinx<5 is causing an error when we try to upgrade sphinx in numpy:
- https://github.com/numpy/numpy/pull/21723

Since you've started using upper pins on newer versions of breathe, pip install breathe==4.15 when sphinx==5.0.1 is installed.
```
$ pip install breathe sphinx==5.0.1
<...>
Successfully installed breathe-4.15.0 six-1.16.0 sphinx-5.0.1
```