### PR TITLE
cicd: disable python 3.6 for sphinx master

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,11 +18,15 @@ jobs:
           - git+https://github.com/sphinx-doc/sphinx.git@5.0.x
           - git+https://github.com/sphinx-doc/sphinx.git@5.x
           - git+https://github.com/sphinx-doc/sphinx.git@master
-        # avoid bug in following configurations
-        # sphinx/util/typing.py:37: in <module>
-        #     from types import Union as types_Union
-        # ImportError: cannot import name 'Union' from 'types'
         exclude:
+          # Since sphinx 7e68154e49fbb260f7ffee9791bfafdb7fd2e119 python 3.6
+          # support is removed. Breathe will probably also drop 3.6 soon.
+          - python-version: '3.6'
+            sphinx-version: git+https://github.com/sphinx-doc/sphinx.git@master
+          # avoid bug in following configurations
+          # sphinx/util/typing.py:37: in <module>
+          #     from types import Union as types_Union
+          # ImportError: cannot import name 'Union' from 'types'
           - python-version: '3.10'
             sphinx-version: '4.0.3'
           - python-version: '3.10'


### PR DESCRIPTION
Unsupported since sphinx-doc/sphinx@7e68154e49fbb260f7ffee9791bfafdb7fd2e119