### PR TITLE
Fix doxygengroup not showing C++ concepts

### DIFF
--- a/breathe/finder/compound.py
+++ b/breathe/finder/compound.py
@@ -34,6 +34,9 @@ class CompoundDefTypeSubItemFinder(ItemFinder[parser.Node_compounddefType]):
         for innerclass in self.node.value.innerclass:
             self.run_filter(filter_, matches, node_stack, innerclass, "innerclass")
 
+        for innerconcept in self.node.value.innerconcept:
+            self.run_filter(filter_, matches, node_stack, innerconcept, "innerconcept")
+
 
 class SectionDefTypeSubItemFinder(ItemFinder[parser.Node_sectiondefType]):
     def filter_(self, ancestors, filter_: DoxFilter, matches: list[FinderMatch]) -> None:

--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -273,7 +273,7 @@ def create_innerclass_filter(options: DoxNamespaceOptions, outerclass: str = "")
         return (
             not (
                 isinstance(node, parser.Node_refType)
-                and nstack.tag == "innerclass"
+                and nstack.tag in ["innerclass", "innerconcept"]
                 and isinstance(parent, parser.Node_compounddefType)
                 and parent.kind in CLASS_LIKE_COMPOUNDDEF
             )

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1705,6 +1705,7 @@ class SphinxRenderer(metaclass=NodeVisitor):
 
         # Take care of innerclasses
         addnode("innerclass", lambda: self.render_iterable(node.innerclass, "innerclass"))
+        addnode("innerconcept", lambda: self.render_iterable(node.innerconcept, "innerconcept"))
         addnode(
             "innernamespace", lambda: self.render_iterable(node.innernamespace, "innernamespace")
         )


### PR DESCRIPTION
No longer ignores innerconcept XML elements in groups.

See breathe-doc/breathe#907