### PR TITLE
Add AutoDoxygen caching

### DIFF
--- a/breathe/directives/setup.py
+++ b/breathe/directives/setup.py
@@ -27,7 +27,7 @@ from breathe.directives.item import (
     DoxygenVariableDirective,
 )
 from breathe.parser import DoxygenParser
-from breathe.process import AutoDoxygenProcessHandle, AutoDoxygenCache
+from breathe.process import AutoDoxygenCache, AutoDoxygenProcessHandle
 from breathe.project import ProjectInfoFactory
 
 if TYPE_CHECKING:

--- a/breathe/process.py
+++ b/breathe/process.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from shlex import quote
 from typing import TYPE_CHECKING
 
-from breathe.project import AutoProjectInfo, ProjectInfoFactory
 from breathe.file_state_cache import MTimeError
+from breathe.project import AutoProjectInfo, ProjectInfoFactory
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -42,9 +42,10 @@ class ProjectData:
         self.auto_project_info = auto_project_info
         self.files = files
 
+
 class AutoDoxygenCache:
     """Simple handler for the doxygen cache information."""
-    
+
     @staticmethod
     def _getmtime(filename: str):
         try:
@@ -61,7 +62,7 @@ class AutoDoxygenCache:
             return False  # No files to check, so no update needed?
         name = info.name()
         try:
-             #TODO: Are project names unique?
+            # TODO: Are project names unique?
             cached_time = self._cache[name]
         except KeyError:
             return True  # Project not cached yet
@@ -79,6 +80,7 @@ class AutoDoxygenCache:
             return
         mtime = max(self._getmtime(file_) for file_ in full_paths)
         self._cache[name] = mtime
+
 
 class AutoDoxygenProcessHandle:
     def __init__(
@@ -142,13 +144,13 @@ class AutoDoxygenProcessHandle:
 
         build_dir = Path(auto_project_info.build_dir(), "breathe", "doxygen")
         project_path = os.path.join(build_dir, name, "xml")
-        
-        if not doxygen_cache.needs_update(auto_project_info, files): 
-            #TODO: Should we also pass the config into the cache check, to see if that has changed?
+
+        if not doxygen_cache.needs_update(auto_project_info, files):
+            # TODO: Should we also pass the config into the cache check, to see if that has changed?
             return project_path
 
         cfgfile = f"{name}.cfg"
-        
+
         self.write_file(build_dir, cfgfile, cfg)
 
         # Shell-escape the cfg file name to try to avoid any issue where the name might include

--- a/breathe/project.py
+++ b/breathe/project.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import fnmatch
-import os
 import os.path
 from pathlib import Path
 from typing import TYPE_CHECKING


### PR DESCRIPTION
Addresses issue #1045 

Considerations:
- After the Doxygen build, I cache an entry of a) the project name and b) the timestamp most recently modified source file. In subsequent builds, we skip re-running the Doxygen command if no source file has been further modified, as we can assume the output directory already contains up-to-date XML files.
- We might want to cache the whole Doxygen configuration/build command (which includes `doxygen_options` and `doxygen_aliases`), and force a rebuild if any of those have changed too. That would be easy to add.
- The "key" I use for the cache is the Breathe Project name. If that is not unique, we should use something different for the key (perhaps the hash of the entire Doxygen configuration/command?)