### PR TITLE
Fix handling of Doxygen property members (Q_PROPERTY)

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -312,6 +312,7 @@ class DomainDirectiveFactory:
         "namespace": (CPPTypeObject, "type"),
         "enumvalue": (CPPEnumeratorObject, "enumerator"),
         "define": (CMacroObject, "macro"),
+        "property": (CPPMemberObject, "member"),
     }
     c_classes: dict[str, tuple[type[ObjectDescription], str]] = {
         "variable": (CMemberObject, "var"),


### PR DESCRIPTION
### Summary
This PR fixes a crash in Breathe that occurs when Doxygen emits a <memberdef kind="property"> element, which is typically produced when parsing Qt’s Q_PROPERTY macro. Breathe currently has no mapping for the property kind in the internal DomainDirectiveFactory, causing a KeyError during documentation rendering.

This change adds handling for Doxygen "property" members and maps them to an appropriate Sphinx C++ domain directive so that Breathe can continue rendering without error.

### Problem
Qt’s Q_PROPERTY macro is widely used in C++/Qt projects.
Doxygen interprets these macros and generates XML entries like: `<memberdef kind="property" ...>`
When Breathe processes the XML and attempts to dispatch this member kind, it fails because "property" is not included in the cpp_classes mapping.

This results in an exception:
```
KeyError: 'property'
  File ".../breathe/renderer/sphinxrenderer.py", line 338, in create
    cls, name = DomainDirectiveFactory.cpp_classes[args[0]]
```

### Reproduction/Example
```C++
class Example : public QObject {
    Q_OBJECT

    /*
    * \property value 
    * The existence of this will fail
    */
    Q_PROPERTY(double value READ value WRITE setValue)

private:
    double value() const;
    void setValue(double);
};

```
With this input, Doxygen generates a property entry which Breathe cannot process, triggering the above KeyError.

### Thank you
Thank you for maintaining Breathe and continuing to support the C++/Sphinx ecosystem.
I hope this patch helps improve Qt compatibility and avoid crashes for other users facing the same issue.