### PR TITLE
Use a proper Node type when content-only is active

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1550,7 +1550,12 @@ class SphinxRenderer(metaclass=NodeVisitor):
             rst_node["objtype"] = kind.value
             rst_node["domain"] = self.get_domain() or "cpp"
 
-            contentnode = addnodes.desc_content()
+            contentnode: nodes.Node
+            if "content-only" in options:
+                contentnode = nodes.paragraph()
+            else:
+                contentnode = addnodes.desc_content()
+
             rst_node.append(contentnode)
 
             return [rst_node], contentnode


### PR DESCRIPTION
If the content-only option is used, HTML \<dl> and \<dt> tags are not generated, but \<dd> is still present. This leads to extra indentation and, in general, results in an orphaned \<dd> element.