### PR TITLE
fix: CI test dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3"
+        python-version: "3.9"
 
     - name: Install dependencies
       # "--editable" is needed so that _parser.py is placed in the local folder

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,10 +38,8 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
         sphinx-version:
-          - '6.2'
-          - '7.0'
-          - '7.1'
           - '7.2' # Ubuntu 24.04
           # version 7.3 broke up the domain modules into packages, changing
           # where some classes had to be imported from
@@ -111,6 +109,12 @@ jobs:
         pip install --upgrade pip
         pip install --editable .[build]
         pip install --editable .[test]
+
+    - name: Version info
+      run: |
+        echo 'python: ' && python --version
+        echo 'sphinx: ' && sphinx-build --version
+        echo 'doxygen: ' && doxygen --version
 
     - name: Generate parser
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,10 @@ docs = [
 ]
 lint = [
     "ruff==0.9.2",
-    "mypy>=1",
+    "mypy>=1,<1.10",
     "types-docutils",
     "types-Pygments",
-    "pytest>=8.0",  # for mypy
+    "pytest>=8.0,<9",  # for mypy
     "sphinxcontrib-phpdomain",  # for mypy
     # The API that we depend on is only implemented in rogerbarton's fork of sphinx-csharp
     # and not in the one that is published to PyPI. But we can't publish Breathe to PyPI with
@@ -63,7 +63,7 @@ lint = [
     # "sphinx-csharp @ git+https://github.com/rogerbarton/sphinx-csharp.git",  # for mypy
 ]
 test = [
-    "pytest>=8.0",
+    "pytest>=8.0,<9",
     "Sphinx[test]"
 ]
 


### PR DESCRIPTION
## Change

- limit dependencies
- remove unsupported sphinx versions
- add python 3.14 to test

## Reference

fixes #1063