### PR TITLE
chore: remove outdated sphinx <7.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3"
+        python-version: "3.9"
 
     - name: Install dependencies
       # "--editable" is needed so that _parser.py is placed in the local folder

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,10 +38,8 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
         sphinx-version:
-          - '6.2'
-          - '7.0'
-          - '7.1'
           - '7.2' # Ubuntu 24.04
           # version 7.3 broke up the domain modules into packages, changing
           # where some classes had to be imported from
@@ -111,6 +109,12 @@ jobs:
         pip install --upgrade pip
         pip install --editable .[build]
         pip install --editable .[test]
+
+    - name: Version info
+      run: |
+        echo 'python: ' && python --version
+        echo 'sphinx: ' && sphinx-build --version
+        echo 'doxygen: ' && doxygen --version
 
     - name: Generate parser
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,10 @@ docs = [
 ]
 lint = [
     "ruff==0.9.2",
-    "mypy>=1",
+    "mypy>=1,<1.10",
     "types-docutils",
     "types-Pygments",
-    "pytest>=8.0",  # for mypy
+    "pytest>=8.0,<9",  # for mypy
     "sphinxcontrib-phpdomain",  # for mypy
     # The API that we depend on is only implemented in rogerbarton's fork of sphinx-csharp
     # and not in the one that is published to PyPI. But we can't publish Breathe to PyPI with
@@ -63,7 +63,7 @@ lint = [
     # "sphinx-csharp @ git+https://github.com/rogerbarton/sphinx-csharp.git",  # for mypy
 ]
 test = [
-    "pytest>=8.0",
+    "pytest>=8.0,<9",
     "Sphinx[test]"
 ]
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,24 +6,12 @@ import os
 import pathlib
 import shutil
 import subprocess
-from typing import TYPE_CHECKING
 from xml.parsers import expat
 
 import pytest
 import sphinx
 
 from breathe.process import AutoDoxygenProcessHandle
-
-if TYPE_CHECKING:
-    from typing import Any
-
-sphinx_path: Any
-
-if sphinx.version_info < (7, 2, 0):
-    from sphinx.testing.path import path as sphinx_path
-else:
-    sphinx_path = pathlib.Path
-
 
 C_FILE_SUFFIXES = frozenset((".h", ".c", ".hpp", ".cpp"))
 IGNORED_ELEMENTS: frozenset[str] = frozenset(())
@@ -301,7 +289,7 @@ def run_sphinx_and_compare(make_app, tmp_path, test_input, overrides, version):
 
     make_app(
         buildername="xml",
-        srcdir=sphinx_path(tmp_path),
+        srcdir=tmp_path,
         confoverrides=conf_overrides(overrides),
     ).build()
 


### PR DESCRIPTION
Removes outdated code.

Includes CI fix #1064 so tests can run.