### PR TITLE
 chore: remove outdated sphinx <6 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3"
+        python-version: "3.9"
 
     - name: Install dependencies
       # "--editable" is needed so that _parser.py is placed in the local folder

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,10 +38,8 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
         sphinx-version:
-          - '6.2'
-          - '7.0'
-          - '7.1'
           - '7.2' # Ubuntu 24.04
           # version 7.3 broke up the domain modules into packages, changing
           # where some classes had to be imported from
@@ -111,6 +109,12 @@ jobs:
         pip install --upgrade pip
         pip install --editable .[build]
         pip install --editable .[test]
+
+    - name: Version info
+      run: |
+        echo 'python: ' && python --version
+        echo 'sphinx: ' && sphinx-build --version
+        echo 'doxygen: ' && doxygen --version
 
     - name: Generate parser
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,10 @@ docs = [
 ]
 lint = [
     "ruff==0.9.2",
-    "mypy>=1",
+    "mypy>=1,<1.10",
     "types-docutils",
     "types-Pygments",
-    "pytest>=8.0",  # for mypy
+    "pytest>=8.0,<9",  # for mypy
     "sphinxcontrib-phpdomain",  # for mypy
     # The API that we depend on is only implemented in rogerbarton's fork of sphinx-csharp
     # and not in the one that is published to PyPI. But we can't publish Breathe to PyPI with
@@ -63,7 +63,7 @@ lint = [
     # "sphinx-csharp @ git+https://github.com/rogerbarton/sphinx-csharp.git",  # for mypy
 ]
 test = [
-    "pytest>=8.0",
+    "pytest>=8.0,<9",
     "Sphinx[test]"
 ]
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -220,14 +220,6 @@ def compare_xml(generated, input_dir, version):
 
                 # ignore extra attributes in o_node
                 for key, value in c_node.attr.items():
-                    if (
-                        c_node.name == "desc_inline"
-                        and key == "domain"
-                        and sphinx.version_info[0] < 6
-                    ):
-                        # prior to Sphinx 6, this attribute was not present
-                        continue
-
                     assert key in o_node.attr, f"missing attribute at line {o_node.line_no}: {key}"
                     o_value = o_node.attr[key]
                     assert attr_compare(key, o_value, value), (


### PR DESCRIPTION
Removes outdated code.

Includes CI fix #1064 so tests can run.